### PR TITLE
fix: Fixed rpyc_server on ESXi

### DIFF
--- a/mfd_connect/__init__.py
+++ b/mfd_connect/__init__.py
@@ -2,30 +2,26 @@
 # SPDX-License-Identifier: MIT
 """Package for Connection implementations."""
 
-import sys
 import logging
 
 logger = logging.getLogger(__name__)
 
-if "-m" in sys.argv and "mfd_connect.rpyc_server" in sys.argv:
-    logger.log(logging.DEBUG, "Running as a module - skipping importing in mfd_connect.__init__")
-else:
-    import platform
+import platform
 
-    from mfd_typing import OSName
+from mfd_typing import OSName
 
-    from .base import Connection, AsyncConnection, PythonConnection
-    from .local import LocalConnection
-    from .rpyc import RPyCConnection
-    from .tunneled_rpyc import TunneledRPyCConnection
-    from .sol import SolConnection
-    from .serial import SerialConnection
-    from .telnet.telnet import TelnetConnection
+from .base import Connection, AsyncConnection, PythonConnection
+from .local import LocalConnection
+from .rpyc import RPyCConnection
+from .tunneled_rpyc import TunneledRPyCConnection
+from .sol import SolConnection
+from .serial import SerialConnection
+from .telnet.telnet import TelnetConnection
+
+if platform.system() != OSName.ESXI.value:
     from .winrm import WinRmConnection
-
-    if platform.system() != OSName.ESXI.value:
-        from .ssh import SSHConnection
-        from .interactive_ssh import InteractiveSSHConnection
-        from .tunneled_ssh import TunneledSSHConnection
-        from .rpyc_zero_deploy import RPyCZeroDeployConnection
-        from .pxssh import PxsshConnection
+    from .ssh import SSHConnection
+    from .interactive_ssh import InteractiveSSHConnection
+    from .tunneled_ssh import TunneledSSHConnection
+    from .rpyc_zero_deploy import RPyCZeroDeployConnection
+    from .pxssh import PxsshConnection


### PR DESCRIPTION
This pull request simplifies the initialization logic in the `mfd_connect` package by removing a conditional block related to module execution and reorganizing imports for better clarity and platform-specific handling.

### Simplification of initialization logic:
* Removed the conditional check for module execution (`if "-m" in sys.argv and "mfd_connect.rpyc_server" in sys.argv`) and the associated `sys` import. This simplifies the `__init__.py` file by focusing solely on package initialization without runtime-specific conditions. (`[mfd_connect/__init__.pyL5-L12](diffhunk://#diff-bde6749f5cc8d9856ee065363f7a87d5cfc3018e2082b8378d939f57cf9ca16eL5-L12)`)

### Reorganization of imports:
* Moved the import of `WinRmConnection` to within the platform-specific block, ensuring it is only imported when the platform is not ESXi. This aligns with the conditional logic for other platform-specific imports like `SSHConnection` and its variants. (`[mfd_connect/__init__.pyL24-R22](diffhunk://#diff-bde6749f5cc8d9856ee065363f7a87d5cfc3018e2082b8378d939f57cf9ca16eL24-R22)`)