### PR TITLE
feat: Add with_privileges parameter to SSHConnection for elevated com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ It's a Connection done by paramiko library.
 
 Constructor:
 
-`SSHConnection(ip: str, port: int = 22, username: str, password: Optional[str], key_path: Optional[Union[List[Union[str, "Path"]], str, "Path"]] = None, skip_key_verification: bool = False, model: "BaseModel | None" = None, default_timeout: int | None = None,)`
+`SSHConnection(ip: str, port: int = 22, username: str, password: Optional[str], key_path: Optional[Union[List[Union[str, "Path"]], str, "Path"]] = None, skip_key_verification: bool = False, model: "BaseModel | None" = None, default_timeout: int | None = None, with_privileges: bool = False)`
 ```python
 """
 Initialise SSHConnection.
@@ -300,6 +300,7 @@ Initialise SSHConnection.
 :param skip_key_verification: To skip checking of host's key, equivalent of StrictHostKeyChecking=no
 :param model: pydantic model of connection
 :param default_timeout: Set default_timeout property.
+:param with_privileges: Whether to use sudo or runas for commands that require elevated privileges
 """
 ```
 

--- a/mfd_connect/ssh.py
+++ b/mfd_connect/ssh.py
@@ -73,6 +73,7 @@ class SSHConnection(AsyncConnection):
         model: "BaseModel | None" = None,
         default_timeout: int | None = None,
         cache_system_data: bool = True,
+        with_privileges: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -91,9 +92,10 @@ class SSHConnection(AsyncConnection):
         :param model: pydantic model of connection
         :param default_timeout: Timeout value for executing timeout for entire class.
         :param cache_system_data: Flag to cache system data like self._os_type, OS name, OS bitness and CPU architecture
+        :param with_privileges: Whether to use sudo or runas for commands that require elevated privileges
         """
         super().__init__(ip, model, default_timeout, cache_system_data)
-        self.__use_sudo = False
+        self.__use_sudo = with_privileges
         self._ip = IPAddress(ip)
         self._connection = SSHClient()
         self._connection_details = {


### PR DESCRIPTION
This pull request adds support for running commands with elevated privileges (such as using `sudo` or `runas`) in the `SSHConnection` class. The new `with_privileges` parameter allows users to specify if commands should be executed with these privileges. The documentation and constructor have been updated to reflect this change.

Enhancement: Support for elevated privileges

* Added a `with_privileges` parameter to the `SSHConnection` constructor in both the code (`mfd_connect/ssh.py`) and documentation (`README.md`), allowing users to specify whether commands should be run with elevated privileges. [[1]](diffhunk://#diff-13c505df72af86151fe844c0e8ef87c1e09811f66609c891f1c91339725026a4R76) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L289-R289)
* Updated the docstrings in both the code and the documentation to describe the new `with_privileges` parameter and its purpose. [[1]](diffhunk://#diff-13c505df72af86151fe844c0e8ef87c1e09811f66609c891f1c91339725026a4R95-R98) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R303)
* Modified the internal logic to set `self.__use_sudo` based on the value of `with_privileges`, enabling or disabling privileged command execution accordingly.