### PR TITLE
fix: Read_text hangs indefinitely on SSH connection

### DIFF
--- a/mfd_connect/pathlib/path.py
+++ b/mfd_connect/pathlib/path.py
@@ -400,7 +400,8 @@ class CustomPosixPath(CustomPath, PurePosixPath):
         )
 
     def read_text(self, encoding: Optional[str] = None, errors: Optional["Iterable"] = None) -> str:  # noqa:D102
-        return self._owner.execute_command(f"cat {self}", expected_return_codes=None).stdout
+        proc = self._owner.start_process(f"cat {self}")
+        return "".join(chunk for chunk in proc.get_stdout_iter())
 
     def touch(self, mode: int = 0o666, exist_ok: bool = True) -> None:  # noqa:D102
         if not exist_ok and self.is_file():

--- a/tests/unit/test_mfd_connect/test_pathlib/test_path.py
+++ b/tests/unit/test_mfd_connect/test_pathlib/test_path.py
@@ -296,12 +296,13 @@ class TestCustomPosixPath:
             "diff a c", expected_return_codes=None, discard_stdout=True
         )
 
-    def test_read_text(self, custom_posix_path):
-        custom_posix_path._owner.execute_command.return_value = ConnectionCompletedProcess(
-            return_code=0, args="command", stdout="content of file", stderr="stderr"
-        )
-        assert custom_posix_path.read_text() == "content of file"
-        custom_posix_path._owner.execute_command.assert_called_once_with("cat a", expected_return_codes=None)
+    def test_read_text(self, custom_posix_path, mocker):
+        mock_process = mocker.MagicMock()
+        mock_process.get_stdout_iter.return_value = iter(["content ", "of ", "file"])
+        custom_posix_path._owner.start_process.return_value = mock_process
+        result = custom_posix_path.read_text()
+        assert result == "content of file"
+        custom_posix_path._owner.start_process.assert_called_once_with("cat a")
 
     def test_write_text(self, custom_posix_path):
         text_to_write = "some text\nsome data"


### PR DESCRIPTION
This pull request introduces improvements to the `CustomPath` class in `mfd_connect/pathlib/path.py`, focusing on compatibility and robustness. The main changes include adding custom division operator methods for path joining and updating the file reading method to use a more reliable process-based approach.

Compatibility enhancements:

* Added `__truediv__` and `__rtruediv__` methods to `CustomPath` to support path joining with proper owner propagation, improving compatibility with older Python versions.

Robustness improvements:

* Updated the `read_text` method to use a process iterator for reading file contents, which enhances reliability when handling large files or streaming output.