### PR TITLE
feat: Implement uptime reading and verification for platform reboot

### DIFF
--- a/mfd_connect/ssh.py
+++ b/mfd_connect/ssh.py
@@ -12,6 +12,7 @@ from subprocess import CalledProcessError
 from typing import Iterable, Type, Optional, Dict, Tuple, List, Union, TYPE_CHECKING
 
 from mfd_common_libs import TimeoutCounter, add_logging_level, log_levels
+from mfd_connect.util.rpc_system_info_utils import read_uptime
 from mfd_typing.cpu_values import CPUArchitecture
 from mfd_typing.os_values import OSBitness, OSType, OSName
 from netaddr import IPAddress
@@ -1015,7 +1016,28 @@ class SSHConnection(AsyncConnection):
         """
         posix_command = self._adjust_command("shutdown -r now")
         restart_commands = {OSType.WINDOWS: "shutdown /r /f -t 0", OSType.POSIX: posix_command}
-        self.send_command_and_disconnect_platform(restart_commands[self._os_type])
+        restart_command = restart_commands[self._os_type]
+
+        # All OSes support uptime-based reboot verification
+        uptime_before = read_uptime(self)
+        self.send_command_and_disconnect_platform(restart_command)
+        while True:
+            try:
+                self.wait_for_host(timeout=1)
+            except TimeoutError:
+                logger.log(level=log_levels.MODULE_DEBUG, msg="Host is not available, means that it is rebooting.")
+                return
+
+            uptime_after = read_uptime(self)
+            if uptime_after < uptime_before:
+                logger.log(level=log_levels.MODULE_DEBUG, msg="Machine rebooted successfully.")
+                return
+
+            logger.log(
+                level=log_levels.MODULE_DEBUG,
+                msg="Uptime is greater than earlier which means that machine did not reboot properly.",
+            )
+            time.sleep(5)
 
     def shutdown_platform(self) -> None:
         """

--- a/mfd_connect/util/rpc_system_info_utils.py
+++ b/mfd_connect/util/rpc_system_info_utils.py
@@ -428,3 +428,66 @@ def is_current_kernel_version_equal_or_higher(connection: "Connection", version:
         raise RuntimeError(f"Wrong kernel version: {kernel_version}")
 
     return current_kernel_version >= version
+
+
+def read_uptime(connection: "Connection") -> float:
+    """Read uptime from host."""
+    os_name = connection.get_os_name()
+    if os_name == OSName.LINUX:
+        return _read_uptime_linux(connection)
+    if os_name in [OSName.FREEBSD, OSName.ESXI]:
+        return _read_uptime_uptime_command(connection)
+    if os_name == OSName.WINDOWS:
+        return _read_uptime_windows(connection)
+    else:
+        raise NotImplementedError(f"Uptime reading not implemented for {os_name.value}")
+
+
+def _read_uptime_linux(connection: "Connection") -> float:
+    """Read uptime from Linux host via /proc/uptime."""
+    out = connection.execute_command("cat /proc/uptime")
+    try:
+        uptime = float(out.stdout.split()[0])
+    except Exception as e:
+        raise RuntimeError(f"Failed to read uptime from Linux host. Error: {e}")
+    return uptime
+
+
+def _read_uptime_uptime_command(connection: "Connection") -> float:
+    """Read uptime from FreeBSD/ESXi host via uptime command."""
+    out = connection.execute_command("uptime")
+    try:
+        # Parse uptime output: "HH:MM:SS up X days, HH:MM" or "HH:MM:SS up HH:MM"
+        uptime_str = out.stdout.strip()
+        # Extract the part after "up "
+        parts = uptime_str.split("up", 1)[1].strip()
+
+        # Try to match pattern with days: "X days, HH:MM"
+        match = re.search(r"(?P<days>\d+)\s+days?,\s+(?P<hours>\d+):(?P<minutes>\d+)", parts)
+        if match:
+            total_seconds = (
+                int(match.group("days")) * 86400 + int(match.group("hours")) * 3600 + int(match.group("minutes")) * 60
+            )
+        else:
+            # Try to match pattern without days: "HH:MM"
+            match = re.search(r"(?P<hours>\d+):(?P<minutes>\d+)", parts)
+            if match:
+                total_seconds = int(match.group("hours")) * 3600 + int(match.group("minutes")) * 60
+            else:
+                total_seconds = 0
+
+        return float(total_seconds)
+    except Exception as e:
+        raise RuntimeError(f"Failed to read uptime from host via uptime command. Error: {e}")
+
+
+def _read_uptime_windows(connection: "Connection") -> float:
+    """Read uptime from Windows host."""
+    command = "[math]::Floor(((Get-Date) - (Get-CimInstance Win32_OperatingSystem).LastBootUpTime).TotalSeconds)"
+    command = f'powershell.exe -OutPutFormat Text -nologo -noninteractive "{command}"'
+    out = connection.execute_command(command)
+    try:
+        uptime = float(out.stdout.strip())
+    except Exception as e:
+        raise RuntimeError(f"Failed to read uptime from Windows host. Error: {e}")
+    return uptime

--- a/tests/unit/test_mfd_connect/test_ssh.py
+++ b/tests/unit/test_mfd_connect/test_ssh.py
@@ -546,11 +546,49 @@ class TestSSHConnection:
     def test_restart_platform_ssh(self, ssh, mocker):
         ssh._os_type = OSType.POSIX
         ssh._connection = mocker.create_autospec(mfd_connect.ssh.SSHClient)
+        mocker.patch("mfd_connect.ssh.read_uptime", side_effect=[100.0, 10.0])
         ssh.send_command_and_disconnect_platform = mocker.Mock()
+        ssh.wait_for_host = mocker.Mock()
         ssh.restart_platform()
         ssh.send_command_and_disconnect_platform.assert_called_with(
             "shutdown -r now",
         )
+        ssh.wait_for_host.assert_called_once_with(timeout=1)
+
+    def test_restart_platform_windows(self, ssh, mocker):
+        ssh._os_type = OSType.WINDOWS
+        ssh._connection = mocker.create_autospec(mfd_connect.ssh.SSHClient)
+        mocker.patch("mfd_connect.ssh.read_uptime", side_effect=[100.0, 10.0])
+        ssh.send_command_and_disconnect_platform = mocker.Mock()
+        ssh.wait_for_host = mocker.Mock()
+
+        ssh.restart_platform()
+
+        ssh.send_command_and_disconnect_platform.assert_called_once_with("shutdown /r /f -t 0")
+        ssh.wait_for_host.assert_called_once_with(timeout=1)
+
+    def test_restart_platform_timeout_error(self, ssh, mocker):
+        ssh._os_type = OSType.POSIX
+        ssh._connection = mocker.create_autospec(mfd_connect.ssh.SSHClient)
+        mocker.patch("mfd_connect.ssh.read_uptime", return_value=100.0)
+        ssh.send_command_and_disconnect_platform = mocker.Mock()
+        ssh.wait_for_host = mocker.Mock(side_effect=TimeoutError)
+
+        ssh.restart_platform()
+
+        ssh.wait_for_host.assert_called_once_with(timeout=1)
+
+    def test_restart_platform_uptime_not_decreased_then_rebooted(self, ssh, mocker):
+        ssh._os_type = OSType.POSIX
+        ssh._connection = mocker.create_autospec(mfd_connect.ssh.SSHClient)
+        mocker.patch("mfd_connect.ssh.read_uptime", side_effect=[100.0, 200.0, 10.0])
+        mocker.patch("mfd_connect.ssh.time.sleep")
+        ssh.send_command_and_disconnect_platform = mocker.Mock()
+        ssh.wait_for_host = mocker.Mock()
+
+        ssh.restart_platform()
+
+        assert ssh.wait_for_host.call_count == 2
 
     def test_shutdown_platform_ssh_no_sudo(self, ssh, mocker):
         ssh._os_type = OSType.POSIX

--- a/tests/unit/test_mfd_connect/test_utils/test_rpc_system_info_utils.py
+++ b/tests/unit/test_mfd_connect/test_utils/test_rpc_system_info_utils.py
@@ -30,6 +30,10 @@ from mfd_connect.util.rpc_system_info_utils import (
     _get_bios_version_esxi,
     is_current_kernel_version_equal_or_higher,
     get_os_version_mellanox,
+    read_uptime,
+    _read_uptime_linux,
+    _read_uptime_uptime_command,
+    _read_uptime_windows,
 )
 
 
@@ -218,6 +222,118 @@ class TestRPCSystemInfoUtils:
         conn.execute_command = exec_command_mock
 
         assert get_os_version_mellanox(connection=conn) == system_version
+
+    def test_read_uptime_linux(self, conn, mocker):
+        conn.get_os_name = mocker.Mock(return_value=OSName.LINUX)
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(args="args", return_code=0, stdout="123.45 456.78")
+        )
+
+        assert read_uptime(connection=conn) == 123.45
+
+    def test_read_uptime_freebsd(self, conn, mocker):
+        conn.get_os_name = mocker.Mock(return_value=OSName.FREEBSD)
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(
+                args="args", return_code=0, stdout="10:30AM  up  1:30, 1 user, load averages: 0.10, 0.15, 0.20"
+            )
+        )
+
+        # 1 hour + 30 minutes = (1*3600) + (30*60) = 3600 + 1800 = 5400
+        assert read_uptime(connection=conn) == 5400.0
+
+    def test_read_uptime_esxi_with_days(self, conn, mocker):
+        conn.get_os_name = mocker.Mock(return_value=OSName.ESXI)
+        # uptime format: "11:11:13 up 6 days, 19:40:32, load average: 0.05, 0.04, 0.05"
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(
+                args="args", return_code=0, stdout="11:11:13 up 6 days, 19:40, 2 users, load average: 0.05, 0.04, 0.05"
+            )
+        )
+
+        # 6 days + 19 hours + 40 minutes = (6*86400) + (19*3600) + (40*60) = 518400 + 68400 + 2400 = 589200
+        assert read_uptime(connection=conn) == 589200.0
+
+    def test_read_uptime_esxi_without_days(self, conn, mocker):
+        conn.get_os_name = mocker.Mock(return_value=OSName.ESXI)
+        # uptime format: "10:05:22 up 2:30, 1 user, load average: 0.01, 0.02, 0.03"
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(
+                args="args", return_code=0, stdout="10:05:22 up 2:30, 1 user, load average: 0.01, 0.02, 0.03"
+            )
+        )
+
+        # 2 hours + 30 minutes = (2*3600) + (30*60) = 7200 + 1800 = 9000
+        assert read_uptime(connection=conn) == 9000.0
+
+    def test_read_uptime_freebsd_with_days(self, conn, mocker):
+        conn.get_os_name = mocker.Mock(return_value=OSName.FREEBSD)
+        # uptime format: "11:15AM  up  1 day, 2:30, 1 user, load averages: 0.00, 0.00, 0.00"
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(
+                args="args", return_code=0, stdout="11:15AM  up  1 day, 2:30, 1 user, load averages: 0.00, 0.00, 0.00"
+            )
+        )
+
+        # 1 day + 2 hours + 30 minutes = (1*86400) + (2*3600) + (30*60) = 86400 + 7200 + 1800 = 95400
+        assert read_uptime(connection=conn) == 95400.0
+
+    def test_read_uptime_freebsd_without_days(self, conn, mocker):
+        conn.get_os_name = mocker.Mock(return_value=OSName.FREEBSD)
+        # uptime format: "10:20AM  up  3:45, 1 user, load averages: 0.05, 0.04, 0.03"
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(
+                args="args", return_code=0, stdout="10:20AM  up  3:45, 1 user, load averages: 0.05, 0.04, 0.03"
+            )
+        )
+
+        # 3 hours + 45 minutes = (3*3600) + (45*60) = 10800 + 2700 = 13500
+        assert read_uptime(connection=conn) == 13500.0
+
+    def test_read_uptime_windows(self, conn, mocker):
+        conn.get_os_name = mocker.Mock(return_value=OSName.WINDOWS)
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(args="args", return_code=0, stdout="3210\r\n")
+        )
+
+        assert read_uptime(connection=conn) == 3210.0
+
+    def test_read_uptime_not_implemented(self, conn, mocker):
+        conn.get_os_name = mocker.Mock(return_value=OSName.MELLANOX)
+
+        with pytest.raises(NotImplementedError, match="Uptime reading not implemented"):
+            read_uptime(connection=conn)
+
+    def test_read_uptime_linux_invalid_output(self, conn, mocker):
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(args="args", return_code=0, stdout="not_a_number")
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to read uptime from Linux host"):
+            _read_uptime_linux(connection=conn)
+
+    def test_read_uptime_uptime_command_no_match(self, conn, mocker):
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(args="args", return_code=0, stdout="10:00AM  up  just started")
+        )
+
+        assert _read_uptime_uptime_command(connection=conn) == 0.0
+
+    def test_read_uptime_uptime_command_invalid_output(self, conn, mocker):
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(args="args", return_code=0, stdout=None)
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to read uptime from host via uptime command"):
+            _read_uptime_uptime_command(connection=conn)
+
+    def test_read_uptime_windows_invalid_output(self, conn, mocker):
+        conn.execute_command = mocker.Mock(
+            return_value=ConnectionCompletedProcess(args="args", return_code=0, stdout="not_a_number")
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to read uptime from Windows host"):
+            _read_uptime_windows(connection=conn)
 
     def test__get_system_boot_time_linux(self, conn, mocker):
         expected_boot_time = "14:49:49 up 138 days"


### PR DESCRIPTION
This pull request introduces a robust, cross-platform method for reading system uptime and uses it to improve the reliability of platform reboot verification. The main changes include implementing the new `read_uptime` utility, updating the `restart_platform` logic to verify reboot by comparing uptimes, and adding comprehensive unit tests for these features.

**Platform uptime reading and reboot verification:**

* Added the `read_uptime` function and platform-specific helpers (`_read_uptime_linux`, `_read_uptime_uptime_command`, `_read_uptime_windows`) to `mfd_connect/util/rpc_system_info_utils.py`, enabling accurate uptime retrieval for Linux, FreeBSD, ESXi, and Windows systems.
* Updated `restart_platform` in `mfd_connect/ssh.py` to use `read_uptime` before and after issuing a reboot command, ensuring the machine actually rebooted by checking if the uptime decreased. This logic now works for all supported OSes. [[1]](diffhunk://#diff-13c505df72af86151fe844c0e8ef87c1e09811f66609c891f1c91339725026a4L1018-R1040) [[2]](diffhunk://#diff-13c505df72af86151fe844c0e8ef87c1e09811f66609c891f1c91339725026a4R15)

**Testing improvements:**

* Added and expanded unit tests in `tests/unit/test_mfd_connect/test_ssh.py` to cover the new reboot verification logic, including cases for POSIX and Windows, handling of timeout errors, and scenarios where uptime does not decrease immediately.
* Added comprehensive tests for `read_uptime` and its helpers in `tests/unit/test_mfd_connect/test_utils/test_rpc_system_info_utils.py`, covering all supported platforms, output parsing, and error handling. [[1]](diffhunk://#diff-d926885edd44e2e43f3bb8401276cfba6ac5144072f5e4bdb511ac052dd29159R226-R339) [[2]](diffhunk://#diff-d926885edd44e2e43f3bb8401276cfba6ac5144072f5e4bdb511ac052dd29159R33-R36)

These changes make platform restarts more reliable by verifying actual reboots and ensure that uptime reading is well-tested and robust across different operating systems.