### PR TITLE
feat(connect): add execute_command_as_user for Windows and POSIX

### DIFF
--- a/mfd_connect/base.py
+++ b/mfd_connect/base.py
@@ -329,8 +329,10 @@ class Connection(ABC, metaclass=ConnectABCMeta):
                     derive a clean environment from the target user profile.
         :param expected_return_codes: Return codes considered acceptable.
                                       ``None`` means any return code is acceptable.
-        :param shell: Run command through a shell wrapper (``cmd /c`` on Windows,
-                      ``/bin/sh -c`` on POSIX).
+        :param shell: Run command through a shell wrapper (``/bin/sh -c`` on POSIX).
+                      Ignored on Windows: the implementation always wraps the command
+                      in ``cmd.exe /S /C`` so that stdout/stderr can be redirected to
+                      temporary capture files owned by the impersonated user.
         :param custom_exception: Exception class to raise on unexpected return code;
                                  must inherit from CalledProcessError.
         :param skip_logging: Skip logging stdout/stderr.

--- a/mfd_connect/base.py
+++ b/mfd_connect/base.py
@@ -293,6 +293,58 @@ class Connection(ABC, metaclass=ConnectABCMeta):
         """
         pass
 
+    def execute_command_as_user(
+        self,
+        command: str,
+        *,
+        user: str,
+        password: str,
+        domain: str | None = None,
+        cwd: str | None = None,
+        timeout: int | None = None,
+        env: dict | None = None,
+        expected_return_codes: Iterable | None = frozenset({0}),
+        shell: bool = False,
+        custom_exception: Type[CalledProcessError] = None,
+        skip_logging: bool = False,
+    ) -> "ConnectionCompletedProcess":
+        """
+        Run program as a different OS user and wait for its completion.
+
+        Provides a real privilege drop / privilege change instead of relying on
+        ``runas /trustlevel`` which is not honored consistently on Windows
+        Server 2025 over RPyC. On Windows uses LogonUser + CreateProcessAsUser
+        from pywin32. On POSIX uses ``sudo -S -u <user>`` (password forwarded
+        via stdin when provided, ``sudo -n`` when not).
+
+        :param command: Command to execute, with all necessary arguments.
+        :param user: Local or domain user account under which the process is launched.
+        :param password: Password for the user. Required on Windows. On POSIX may be
+                         empty when sudo is configured passwordless.
+        :param domain: Optional Windows domain. ``None`` (default) is the local machine.
+                       Ignored on POSIX.
+        :param cwd: Directory to start program execution in.
+        :param timeout: Program execution timeout, in seconds.
+        :param env: Environment to execute the program in. ``None`` lets the launcher
+                    derive a clean environment from the target user profile.
+        :param expected_return_codes: Return codes considered acceptable.
+                                      ``None`` means any return code is acceptable.
+        :param shell: Run command through a shell wrapper (``cmd /c`` on Windows,
+                      ``/bin/sh -c`` on POSIX).
+        :param custom_exception: Exception class to raise on unexpected return code;
+                                 must inherit from CalledProcessError.
+        :param skip_logging: Skip logging stdout/stderr.
+
+        :return: ConnectionCompletedProcess
+        :raises NotImplementedError: when the connection class does not implement it.
+        :raises RunAsUserNotSupportedError: when the connection's OS is not supported.
+        :raises RunAsUserError: when the launch itself fails (logon, redirect, etc.).
+        :raises ConnectionCalledProcessError: if program exits with an unexpected return code.
+        """
+        raise NotImplementedError(
+            f"execute_command_as_user is not implemented for {self.__class__.__name__}"
+        )
+
     def get_system_info(self) -> SystemInfo:
         """Get SystemInfo."""
         os_name = self.get_os_name()

--- a/mfd_connect/exceptions.py
+++ b/mfd_connect/exceptions.py
@@ -81,6 +81,14 @@ class OsNotSupported(ModuleFrameworkDesignError):
     """Raises when OS is not supported."""
 
 
+class RunAsUserNotSupportedError(ModuleFrameworkDesignError):
+    """Raised when execute_command_as_user is not supported on this connection or OS."""
+
+
+class RunAsUserError(ModuleFrameworkDesignError):
+    """Raised on failure to launch a process as a different user (logon, profile, redirect)."""
+
+
 class CPUArchitectureNotSupported(ModuleFrameworkDesignError):
     """Raises when CPU Architecture is not supported."""
 

--- a/mfd_connect/rpyc.py
+++ b/mfd_connect/rpyc.py
@@ -613,31 +613,47 @@ class RPyCConnection(PythonConnection):
         os_mod = modules.os
         builtins_mod = modules.builtins
 
+        if shell is False:
+            logger.log(
+                level=log_levels.MODULE_DEBUG,
+                msg=(
+                    "execute_command_as_user on Windows always wraps the command in "
+                    "cmd.exe /S /C to redirect stdout/stderr; 'shell=False' is ignored."
+                ),
+            )
+
         out_fd, out_path = tempfile_mod.mkstemp(suffix="_mfd_runas.out")
         err_fd, err_path = tempfile_mod.mkstemp(suffix="_mfd_runas.err")
         os_mod.close(out_fd)
         os_mod.close(err_fd)
 
         # Child is the user's own cmd.exe so the process owns the redirection.
-        cmd_line = f'cmd.exe /S /C "{command} > "{out_path}" 2> "{err_path}""'
+        # The doubled outer quotes around the entire payload are required by
+        # the `cmd.exe /S /C "..."` quoting rules so that inner quotes around
+        # the redirection paths are preserved.
+        cmd_line = f'cmd.exe /S /C ""{command} > "{out_path}" 2> "{err_path}"""'
 
-        logon_domain = domain if domain else "."
-        LOGON32_LOGON_INTERACTIVE = 2
-        LOGON32_PROVIDER_DEFAULT = 0
-        try:
-            token = win32security.LogonUser(
-                user,
-                logon_domain,
-                password,
-                LOGON32_LOGON_INTERACTIVE,
-                LOGON32_PROVIDER_DEFAULT,
-            )
-        except Exception as exc:
-            raise RunAsUserError(f"LogonUser failed for '{user}': {exc}") from exc
-
+        token = None
         h_profile = None
         h_proc = h_thread = None
+        stdout_bytes = b""
+        stderr_bytes = b""
+        return_code = -1
         try:
+            logon_domain = domain if domain else "."
+            LOGON32_LOGON_INTERACTIVE = 2
+            LOGON32_PROVIDER_DEFAULT = 0
+            try:
+                token = win32security.LogonUser(
+                    user,
+                    logon_domain,
+                    password,
+                    LOGON32_LOGON_INTERACTIVE,
+                    LOGON32_PROVIDER_DEFAULT,
+                )
+            except Exception as exc:
+                raise RunAsUserError(f"LogonUser failed for '{user}': {exc}") from exc
+
             try:
                 h_profile = win32profile.LoadUserProfile(token, {"UserName": user})
             except Exception:  # noqa: BLE001 - profile load is best-effort
@@ -665,18 +681,29 @@ class RPyCConnection(PythonConnection):
             except Exception as exc:
                 raise RunAsUserError(f"CreateProcessAsUser failed for '{user}': {exc}") from exc
 
-            timeout_ms = int(timeout * 1000) if timeout else win32event.INFINITE
+            timeout_ms = win32event.INFINITE if timeout is None else int(timeout * 1000)
             wait_result = win32event.WaitForSingleObject(h_proc, timeout_ms)
             if wait_result == win32event.WAIT_TIMEOUT:
                 try:
                     win32process.TerminateProcess(h_proc, 1)
-                finally:
+                except Exception:  # noqa: BLE001 - already failing
                     pass
                 raise TimeoutError(
                     f"execute_command_as_user timed out after {timeout}s for user '{user}'"
                 )
 
             return_code = int(win32process.GetExitCodeProcess(h_proc))
+
+            try:
+                with builtins_mod.open(out_path, "rb") as fh:
+                    stdout_bytes = fh.read()
+            except OSError:
+                stdout_bytes = b""
+            try:
+                with builtins_mod.open(err_path, "rb") as fh:
+                    stderr_bytes = fh.read()
+            except OSError:
+                stderr_bytes = b""
         finally:
             if h_proc is not None:
                 try:
@@ -688,31 +715,21 @@ class RPyCConnection(PythonConnection):
                     win32api.CloseHandle(h_thread)
                 except Exception:  # noqa: BLE001
                     pass
-            if h_profile is not None:
+            if h_profile is not None and token is not None:
                 try:
                     win32profile.UnloadUserProfile(token, h_profile)
                 except Exception:  # noqa: BLE001
                     pass
-            try:
-                win32api.CloseHandle(token)
-            except Exception:  # noqa: BLE001
-                pass
-
-        try:
-            with builtins_mod.open(out_path, "rb") as fh:
-                stdout_bytes = fh.read()
-        except OSError:
-            stdout_bytes = b""
-        try:
-            with builtins_mod.open(err_path, "rb") as fh:
-                stderr_bytes = fh.read()
-        except OSError:
-            stderr_bytes = b""
-        for path in (out_path, err_path):
-            try:
-                os_mod.unlink(path)
-            except OSError:
-                pass
+            if token is not None:
+                try:
+                    win32api.CloseHandle(token)
+                except Exception:  # noqa: BLE001
+                    pass
+            for path in (out_path, err_path):
+                try:
+                    os_mod.unlink(path)
+                except OSError:
+                    pass
 
         completed = CompletedProcess(
             args=command,

--- a/mfd_connect/rpyc.py
+++ b/mfd_connect/rpyc.py
@@ -26,6 +26,8 @@ from mfd_connect.exceptions import (
     OsNotSupported,
     ModuleFrameworkDesignError,
     RPyCDeploymentException,
+    RunAsUserError,
+    RunAsUserNotSupportedError,
 )
 from .process.rpyc import RPyCProcess, WindowsRPyCProcess, PosixRPyCProcess, ESXiRPyCProcess, WindowsRPyCProcessByStart
 from .util.decorators import clear_system_data_cache
@@ -477,6 +479,253 @@ class RPyCConnection(PythonConnection):
         errors = errors if errors else b""
         rc = int(proc.returncode)
         return CompletedProcess(args=command, stdout=output, stderr=errors, returncode=rc)
+
+    def execute_command_as_user(  # noqa: D102
+        self,
+        command: str,
+        *,
+        user: str,
+        password: str,
+        domain: str | None = None,
+        cwd: str | None = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
+        expected_return_codes: Iterable | None = frozenset({0}),
+        shell: bool = False,
+        custom_exception: Type[CalledProcessError] | None = None,
+        skip_logging: bool = False,
+    ) -> "ConnectionCompletedProcess":
+        timeout = self.default_timeout if timeout is None else timeout
+        os_name = self.get_os_name()
+        logger.log(
+            level=log_levels.CMD,
+            msg=(
+                f"Executing as user '{user}'"
+                f"{('@' + domain) if domain else ''} >{self._ip}> '{command}', cwd: {cwd}"
+            ),
+        )
+        if os_name == OSName.WINDOWS:
+            return self._execute_command_as_user_windows(
+                command,
+                user=user,
+                password=password,
+                domain=domain,
+                cwd=cwd,
+                timeout=timeout,
+                env=env,
+                expected_return_codes=expected_return_codes,
+                shell=shell,
+                custom_exception=custom_exception,
+                skip_logging=skip_logging,
+            )
+        if os_name in (OSName.LINUX, OSName.FREEBSD, OSName.ESXI):
+            return self._execute_command_as_user_posix(
+                command,
+                user=user,
+                password=password,
+                cwd=cwd,
+                timeout=timeout,
+                env=env,
+                expected_return_codes=expected_return_codes,
+                shell=shell,
+                custom_exception=custom_exception,
+                skip_logging=skip_logging,
+            )
+        raise RunAsUserNotSupportedError(
+            f"execute_command_as_user is not supported on OS {os_name} via {self.__class__.__name__}"
+        )
+
+    def _execute_command_as_user_posix(
+        self,
+        command: str,
+        *,
+        user: str,
+        password: str | None,
+        cwd: str | None,
+        timeout: int | None,
+        env: dict[str, str] | None,
+        expected_return_codes: Iterable | None,
+        shell: bool,
+        custom_exception: Type[CalledProcessError] | None,
+        skip_logging: bool,
+    ) -> "ConnectionCompletedProcess":
+        """Run command as another user on POSIX via sudo."""
+        inner = command
+        if shell:
+            inner = f"/bin/sh -c {shlex.quote(command)}"
+        if password:
+            wrapped = f"sudo -S -p '' -u {shlex.quote(user)} -- {inner}"
+            input_data = f"{password}\n"
+        else:
+            wrapped = f"sudo -n -u {shlex.quote(user)} -- {inner}"
+            input_data = None
+        return self.execute_command(
+            wrapped,
+            input_data=input_data,
+            cwd=cwd,
+            timeout=timeout,
+            env=env,
+            expected_return_codes=expected_return_codes,
+            shell=False,
+            custom_exception=custom_exception,
+            skip_logging=skip_logging,
+        )
+
+    def _execute_command_as_user_windows(
+        self,
+        command: str,
+        *,
+        user: str,
+        password: str,
+        domain: str | None,
+        cwd: str | None,
+        timeout: int | None,
+        env: dict[str, str] | None,
+        expected_return_codes: Iterable | None,
+        shell: bool,
+        custom_exception: Type[CalledProcessError] | None,
+        skip_logging: bool,
+    ) -> "ConnectionCompletedProcess":
+        """
+        Run command as another user on Windows.
+
+        Uses LogonUser + CreateProcessAsUser via pywin32. Stdout/stderr are
+        redirected to temporary files in the remote temp directory because
+        CreateProcessAsUser does not transparently inherit RPyC stdio handles.
+        """
+        if not password:
+            raise RunAsUserError("password is required to launch a process as another user on Windows")
+
+        modules = self.modules()
+        try:
+            win32security = modules.win32security
+            win32process = modules.win32process
+            win32event = modules.win32event
+            win32api = modules.win32api
+            win32con = modules.win32con
+            win32profile = modules.win32profile
+        except AttributeError as exc:  # pragma: no cover - pywin32 missing on responder
+            raise RunAsUserError(
+                "pywin32 is required on the remote host for execute_command_as_user on Windows"
+            ) from exc
+
+        tempfile_mod = modules.tempfile
+        os_mod = modules.os
+        builtins_mod = modules.builtins
+
+        out_fd, out_path = tempfile_mod.mkstemp(suffix="_mfd_runas.out")
+        err_fd, err_path = tempfile_mod.mkstemp(suffix="_mfd_runas.err")
+        os_mod.close(out_fd)
+        os_mod.close(err_fd)
+
+        # Child is the user's own cmd.exe so the process owns the redirection.
+        cmd_line = f'cmd.exe /S /C "{command} > "{out_path}" 2> "{err_path}""'
+
+        logon_domain = domain if domain else "."
+        LOGON32_LOGON_INTERACTIVE = 2
+        LOGON32_PROVIDER_DEFAULT = 0
+        try:
+            token = win32security.LogonUser(
+                user,
+                logon_domain,
+                password,
+                LOGON32_LOGON_INTERACTIVE,
+                LOGON32_PROVIDER_DEFAULT,
+            )
+        except Exception as exc:
+            raise RunAsUserError(f"LogonUser failed for '{user}': {exc}") from exc
+
+        h_profile = None
+        h_proc = h_thread = None
+        try:
+            try:
+                h_profile = win32profile.LoadUserProfile(token, {"UserName": user})
+            except Exception:  # noqa: BLE001 - profile load is best-effort
+                h_profile = None
+
+            env_block = win32profile.CreateEnvironmentBlock(token, False) if env is None else env
+
+            si = win32process.STARTUPINFO()
+            si.dwFlags = win32con.STARTF_USESHOWWINDOW
+            si.wShowWindow = win32con.SW_HIDE
+
+            try:
+                h_proc, h_thread, _pid, _tid = win32process.CreateProcessAsUser(
+                    token,
+                    None,
+                    cmd_line,
+                    None,
+                    None,
+                    False,
+                    win32con.CREATE_NO_WINDOW | win32con.CREATE_UNICODE_ENVIRONMENT,
+                    env_block,
+                    cwd,
+                    si,
+                )
+            except Exception as exc:
+                raise RunAsUserError(f"CreateProcessAsUser failed for '{user}': {exc}") from exc
+
+            timeout_ms = int(timeout * 1000) if timeout else win32event.INFINITE
+            wait_result = win32event.WaitForSingleObject(h_proc, timeout_ms)
+            if wait_result == win32event.WAIT_TIMEOUT:
+                try:
+                    win32process.TerminateProcess(h_proc, 1)
+                finally:
+                    pass
+                raise TimeoutError(
+                    f"execute_command_as_user timed out after {timeout}s for user '{user}'"
+                )
+
+            return_code = int(win32process.GetExitCodeProcess(h_proc))
+        finally:
+            if h_proc is not None:
+                try:
+                    win32api.CloseHandle(h_proc)
+                except Exception:  # noqa: BLE001
+                    pass
+            if h_thread is not None:
+                try:
+                    win32api.CloseHandle(h_thread)
+                except Exception:  # noqa: BLE001
+                    pass
+            if h_profile is not None:
+                try:
+                    win32profile.UnloadUserProfile(token, h_profile)
+                except Exception:  # noqa: BLE001
+                    pass
+            try:
+                win32api.CloseHandle(token)
+            except Exception:  # noqa: BLE001
+                pass
+
+        try:
+            with builtins_mod.open(out_path, "rb") as fh:
+                stdout_bytes = fh.read()
+        except OSError:
+            stdout_bytes = b""
+        try:
+            with builtins_mod.open(err_path, "rb") as fh:
+                stderr_bytes = fh.read()
+        except OSError:
+            stderr_bytes = b""
+        for path in (out_path, err_path):
+            try:
+                os_mod.unlink(path)
+            except OSError:
+                pass
+
+        completed = CompletedProcess(
+            args=command,
+            stdout=stdout_bytes,
+            stderr=stderr_bytes,
+            returncode=return_code,
+        )
+        return self._handle_execution_outcome(
+            completed_process=completed,
+            expected_return_codes=expected_return_codes,
+            custom_exception=custom_exception,
+            skip_logging=skip_logging,
+        )
 
     def send_command_and_disconnect_platform(self, command: str) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = { file = ["requirements.txt"] }
 name = "mfd-connect"
 description = "Module for running commands on remote machine."
 requires-python = ">=3.10, <3.14"
-version = "7.16.0"
+version = "7.18.0"
 dynamic = ["dependencies"]
 license-files = ["LICENSE.md", "AUTHORS.md"]
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/tests/unit/test_mfd_connect/test_run_as_user.py
+++ b/tests/unit/test_mfd_connect/test_run_as_user.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 """Unit tests for execute_command_as_user on RPyCConnection."""
 
-from subprocess import CompletedProcess
 from unittest.mock import patch, MagicMock
 
 import pytest

--- a/tests/unit/test_mfd_connect/test_run_as_user.py
+++ b/tests/unit/test_mfd_connect/test_run_as_user.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: MIT
+"""Unit tests for execute_command_as_user on RPyCConnection."""
+
+from subprocess import CompletedProcess
+from unittest.mock import patch, MagicMock
+
+import pytest
+from mfd_typing.os_values import OSName, OSType
+
+from mfd_connect import RPyCConnection
+from mfd_connect.exceptions import RunAsUserError, RunAsUserNotSupportedError
+
+
+class TestExecuteCommandAsUser:
+    """Tests for RPyCConnection.execute_command_as_user."""
+
+    @pytest.fixture()
+    def rpyc(self, mocker):
+        with patch.object(RPyCConnection, "__init__", return_value=None):
+            conn = RPyCConnection(ip="10.10.10.10")
+            conn._ip = "10.10.10.10"
+            conn._os_type = conn._cached_os_type = OSType.POSIX
+            conn._default_timeout = None
+            conn.path_extension = None
+            conn.cache_system_data = True
+            return conn
+
+    def test_posix_with_password_uses_sudo_S(self, rpyc, mocker):
+        rpyc.get_os_name = mocker.Mock(return_value=OSName.LINUX)
+        rpyc.execute_command = mocker.Mock()
+        rpyc.execute_command_as_user(
+            "/bin/tool -i -l",
+            user="qv_user",
+            password="secret",
+        )
+        called_cmd = rpyc.execute_command.call_args[0][0]
+        called_kwargs = rpyc.execute_command.call_args[1]
+        assert called_cmd.startswith("sudo -S -p '' -u qv_user --")
+        assert "/bin/tool -i -l" in called_cmd
+        assert called_kwargs["input_data"] == "secret\n"
+
+    def test_posix_without_password_uses_sudo_n(self, rpyc, mocker):
+        rpyc.get_os_name = mocker.Mock(return_value=OSName.FREEBSD)
+        rpyc.execute_command = mocker.Mock()
+        rpyc.execute_command_as_user(
+            "/bin/tool -i -l",
+            user="qv_user",
+            password="",
+        )
+        called_cmd = rpyc.execute_command.call_args[0][0]
+        called_kwargs = rpyc.execute_command.call_args[1]
+        assert called_cmd.startswith("sudo -n -u qv_user --")
+        assert called_kwargs["input_data"] is None
+
+    def test_unsupported_os_raises(self, rpyc, mocker):
+        rpyc.get_os_name = mocker.Mock(return_value=OSName.EFISHELL)
+        with pytest.raises(RunAsUserNotSupportedError):
+            rpyc.execute_command_as_user(
+                "tool",
+                user="u",
+                password="p",
+            )
+
+    def test_windows_requires_password(self, rpyc, mocker):
+        rpyc.get_os_name = mocker.Mock(return_value=OSName.WINDOWS)
+        with pytest.raises(RunAsUserError):
+            rpyc.execute_command_as_user(
+                "C:\\nvmupdate.exe -i",
+                user="qv_user",
+                password="",
+            )
+
+    def test_windows_logon_failure_raises_runasusererror(self, rpyc, mocker):
+        rpyc.get_os_name = mocker.Mock(return_value=OSName.WINDOWS)
+        modules = MagicMock()
+        modules.tempfile.mkstemp.side_effect = [(1, "C:\\Temp\\out"), (2, "C:\\Temp\\err")]
+        modules.os.close = MagicMock()
+        modules.win32security.LogonUser.side_effect = RuntimeError("boom")
+        rpyc.modules = mocker.Mock(return_value=modules)
+        with pytest.raises(RunAsUserError):
+            rpyc.execute_command_as_user(
+                "tool.exe",
+                user="qv_user",
+                password="secret",
+            )
+
+    def test_windows_happy_path_returns_completed_process(self, rpyc, mocker):
+        rpyc.get_os_name = mocker.Mock(return_value=OSName.WINDOWS)
+        modules = MagicMock()
+        modules.tempfile.mkstemp.side_effect = [(1, "C:\\Temp\\out"), (2, "C:\\Temp\\err")]
+        modules.win32event.WAIT_TIMEOUT = 258
+        modules.win32event.INFINITE = -1
+        modules.win32event.WaitForSingleObject.return_value = 0
+        modules.win32process.GetExitCodeProcess.return_value = 1
+        modules.win32process.CreateProcessAsUser.return_value = (object(), object(), 1234, 1)
+
+        out_handle = MagicMock()
+        out_handle.__enter__.return_value.read.return_value = b"Administrator privileges are needed to run application.\r\n"
+        err_handle = MagicMock()
+        err_handle.__enter__.return_value.read.return_value = b""
+        modules.builtins.open.side_effect = [out_handle, err_handle]
+        rpyc.modules = mocker.Mock(return_value=modules)
+
+        result = rpyc.execute_command_as_user(
+            "C:\\nvmupdate.exe -i -l",
+            user="qv_user",
+            password="secret",
+            expected_return_codes=None,
+        )
+        assert result.return_code == 1
+        assert "Administrator privileges are needed" in result.stdout
+
+    def test_default_raises_not_implemented_on_base(self):
+        from mfd_connect.base import Connection
+        instance = Connection.__new__(Connection)
+        with pytest.raises(NotImplementedError):
+            instance.execute_command_as_user("x", user="u", password="p")


### PR DESCRIPTION
Adds Connection.execute_command_as_user with default NotImplementedError and an RPyCConnection implementation that:

- on Windows uses LogonUser + CreateProcessAsUser via pywin32 with redirected stdout/stderr temp files (real privilege change, unlike runas /trustlevel which is unreliable on Windows Server 2025 over RPyC)

- on POSIX wraps the command in sudo -S/-u (password forwarded via stdin) or sudo -n when password is empty

Adds RunAsUserError and RunAsUserNotSupportedError exceptions and unit tests covering POSIX, Windows happy/error paths, and the default NotImplementedError.

Refs FrameworksMFD-7813.