### PR TITLE
feat: Add user management utilities and run-as-user functionality for…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Otherwise, error could be raised due to inconsistency.
   - [Affinity setting](#affinity-setting)
   - [Path manipulation](#path-manipulation)
   - [Additional info about specific Connection implementation](#additional-info-about-specific-connection-implementation)
+  - [RPyCConnection Windows run-as-user and user management](#rpycconnection-windows-run-as-user-and-user-management)
   - [Execute command with sudo](#execute-command-with-sudo)
   - [Execute background command with SSHConnection](#execute-background-command-with-sshconnection)
   - [Recommendation for Connection choice](#recommendation-for-connection-choice)
@@ -744,6 +745,43 @@ Below some known issues correlated with this functionality:
 * Windows: BgServingThread **must be enabled** for async to properly read process output
 * Linux: BgServingThread **must be enabled** to read process output
 * Simics: There is knows issue with long connection time if BgServingThread is enabled, **recommend disabling it**
+
+### RPyCConnection Windows run-as-user and user management
+
+On Windows targets, `RPyCConnection` provides additional helpers for running a command as another user and for local user lifecycle operations.
+
+Available methods:
+
+* `execute_command_as_user(command: str, *, user: str, password: str, domain: str | None = None, cwd: str | None = None, timeout: int | None = None, env: dict[str, str] | None = None, expected_return_codes: Iterable | None = frozenset({0}), shell: bool = False, custom_exception: Type[CalledProcessError] | None = None, skip_logging: bool = False) -> ConnectionCompletedProcess`
+* `create_user(username: str, password: str, *, expected_return_codes: Iterable | None = frozenset({0}), custom_exception: Type[CalledProcessError] | None = None, skip_logging: bool = False) -> ConnectionCompletedProcess`
+* `delete_user(username: str, *, expected_return_codes: Iterable | None = frozenset({0}), custom_exception: Type[CalledProcessError] | None = None, skip_logging: bool = False) -> ConnectionCompletedProcess`
+
+Notes:
+
+* The methods above are supported only on Windows targets.
+* `execute_command_as_user` uses a temporary WinAPI helper on the remote host (`CreateProcessWithLogonW`).
+* For local accounts, use `domain=None` (or `domain="."`).
+
+Example:
+
+```python
+from mfd_connect import RPyCConnection
+
+conn = RPyCConnection(ip="10.10.10.10")
+
+conn.create_user(username="mfd_temp_user", password="pass")
+try:
+  result = conn.execute_command_as_user(
+    command="whoami",
+    user="mfd_temp_user",
+    password="pass",
+    domain=".",
+    timeout=60,
+  )
+  print(result.stdout)
+finally:
+  conn.delete_user(username="mfd_temp_user")
+```
 
 #### PythonConnection/SSHConnection output redirection to file
 

--- a/examples/rpyc_run_as_user_example.py
+++ b/examples/rpyc_run_as_user_example.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: MIT
+
+"""Example: Windows run-as-user and local account management over RPyCConnection."""
+
+from mfd_connect import RPyCConnection
+
+# Configure connection to Windows host with running RPyC server.
+conn = RPyCConnection(ip="10.10.10.10")
+
+# Temporary local account used for the demo.
+username = "mfd_temp_user"
+password = "pass"
+
+try:
+    # Create local user.
+    create_result = conn.create_user(username=username, password=password)
+    print("CREATE USER")
+    print(f"return_code: {create_result.return_code}")
+
+    # Execute command as created user.
+    run_result = conn.execute_command_as_user(
+        command="whoami",
+        user=username,
+        password=password,
+        domain=".",
+        timeout=60,
+    )
+    print("RUN AS USER")
+    print(f"stdout: {run_result.stdout}")
+    print(f"stderr: {run_result.stderr}")
+    print(f"return_code: {run_result.return_code}")
+finally:
+    # Delete temporary user even if command execution fails.
+    delete_result = conn.delete_user(username=username, expected_return_codes={0, 2})
+    print("DELETE USER")
+    print(f"return_code: {delete_result.return_code}")

--- a/mfd_connect/exceptions.py
+++ b/mfd_connect/exceptions.py
@@ -129,6 +129,10 @@ class RPyCDeploymentException(ModuleFrameworkDesignError):
     """Handle exceptions when deployment found issue."""
 
 
+class RunAsUserError(ModuleFrameworkDesignError):
+    """Raised when run-as-user execution setup is invalid."""
+
+
 class MissingPortablePythonOnServerException(RPyCDeploymentException):
     """Handle exceptions when not found portable python on server."""
 

--- a/mfd_connect/rpyc.py
+++ b/mfd_connect/rpyc.py
@@ -3,6 +3,8 @@
 """RPyC Connection implementation."""
 
 import codecs
+import base64
+import json
 import logging
 import shlex
 import time
@@ -26,9 +28,11 @@ from mfd_connect.exceptions import (
     OsNotSupported,
     ModuleFrameworkDesignError,
     RPyCDeploymentException,
+    RunAsUserError,
 )
 from .process.rpyc import RPyCProcess, WindowsRPyCProcess, PosixRPyCProcess, ESXiRPyCProcess, WindowsRPyCProcessByStart
 from .util.decorators import clear_system_data_cache
+from .util.account_utils import create_user as create_user_util, delete_user as delete_user_util
 
 if typing.TYPE_CHECKING:
     from io import TextIOWrapper
@@ -114,6 +118,34 @@ class RPyCConnection(PythonConnection):
         self._ipv6: bool = ipv6
         self._establish_connection(retry_timeout=retry_timeout, retry_time=retry_time)
 
+    def _ensure_remote_winapi_helper(self) -> str:
+        """
+        Upload a fresh WinAPI helper script copy to remote host.
+
+        :return: Absolute path to helper script on remote host.
+        :raises RunAsUserError: If local helper script does not exist.
+        """
+        local_helper_path = Path(__file__).resolve().parent / "util" / "runas_winapi_script.py"
+        if not local_helper_path.exists():
+            raise RunAsUserError(f"WinAPI helper script not found: {local_helper_path}")
+
+        helper_code = local_helper_path.read_text(encoding="utf-8")
+
+        remote_os = self.modules().os
+        remote_pathlib = self.modules().pathlib
+        remote_tempfile = self.modules().tempfile
+
+        remote_helper_dir = remote_os.path.join(remote_tempfile.gettempdir(), "mfd_connect")
+        remote_pathlib.Path(remote_helper_dir).mkdir(parents=True, exist_ok=True)
+        helper_handle, remote_helper_path = remote_tempfile.mkstemp(
+            prefix="runas_winapi_script_",
+            suffix=".py",
+            dir=remote_helper_dir,
+        )
+        remote_os.close(helper_handle)
+        remote_pathlib.Path(remote_helper_path).write_text(helper_code, encoding="utf-8")
+        return remote_helper_path
+
     def _establish_connection(self, *, retry_timeout: Optional[int], retry_time: int) -> None:
         """
         Establish a connection to the machine.
@@ -155,6 +187,13 @@ class RPyCConnection(PythonConnection):
             self.__establish_connection(retry_timeout=retry_timeout, retry_time=retry_time)
 
     def __establish_connection(self, *, retry_timeout: Optional[int], retry_time: int) -> None:
+        """
+        Establish low-level RPyC connection sequence.
+
+        :param retry_timeout: Time window in seconds for host availability checks.
+        :param retry_time: Delay in seconds between retry attempts.
+        :return: ``None``
+        """
         # flow for tries of connecting
         if retry_timeout:
             logger.log(
@@ -267,6 +306,329 @@ class RPyCConnection(PythonConnection):
             service=ClassicService,
             keepalive=True,
             config={"sync_request_timeout": self._connection_timeout},
+        )
+
+    def _execute_command_as_user_windows(
+        self,
+        command: str,
+        *,
+        user: str,
+        password: str,
+        domain: str | None = None,
+        cwd: str | None = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
+        expected_return_codes: Iterable | None = None,
+        shell: bool = False,
+        custom_exception: Type[CalledProcessError] | None = None,
+        skip_logging: bool = False,
+    ) -> "ConnectionCompletedProcess":
+        """
+        Run command as another user on Windows.
+
+        The method uses a WinAPI helper script based on
+        CreateProcessWithLogonW. The helper is uploaded for each call and
+        removed during cleanup after execution.
+
+        :param command: Command line to execute as target user.
+        :param user: Target account user name.
+        :param password: Target account password.
+        :param domain: Account domain name; use ``None`` or ``"."`` for local account.
+        :param cwd: Working directory for launched command.
+        :param timeout: Timeout in seconds for command execution.
+        :param env: Environment variables passed to helper process.
+        :param expected_return_codes: Return codes treated as successful.
+        :param shell: Reserved for API compatibility; command is always wrapped for ``cmd.exe``.
+        :param custom_exception: Exception class raised for unexpected return code.
+        :param skip_logging: Skip stdout/stderr logging for this execution.
+        :return: Completed process result for executed command.
+        :raises RunAsUserError: If called on non-Windows host or credentials are missing.
+        """
+        if not user:
+            raise RunAsUserError("user is required to launch a process as another user on Windows")
+
+        if not password:
+            raise RunAsUserError("password is required to launch a process as another user on Windows")
+
+        timeout = self.default_timeout if timeout is None else timeout
+        timeout_string = " " if timeout is None else f" with timeout {timeout} seconds"
+        logger.log(level=log_levels.CMD, msg=f"Executing as user >{self._ip}> '{command}', cwd: {cwd}{timeout_string}")
+
+        remote_modules = self.modules()
+        remote_tempfile = remote_modules.tempfile
+        remote_os = remote_modules.os
+        remote_pathlib = remote_modules.pathlib
+        remote_subprocess = remote_modules.subprocess
+        remote_python = remote_modules.sys.executable
+        winapi_helper_remote_path = self._ensure_remote_winapi_helper()
+
+        user_temp_dir = remote_os.path.join("C:\\", "Users", user, "AppData", "Local", "Temp")
+        if not remote_os.path.isdir(user_temp_dir):
+            user_temp_dir = remote_os.path.join(remote_os.environ.get("SystemRoot", "C:\\Windows"), "Temp")
+        work_dir = remote_tempfile.mkdtemp(prefix="mfd_runas_", dir=user_temp_dir)
+        grant_identity = f"{domain}\\{user}" if domain and domain not in (".", "") else user
+        try:
+            remote_subprocess.run(
+                f'icacls "{work_dir}" /grant "{grant_identity}:(OI)(CI)F" /T /C',
+                shell=True,
+                stdout=DEVNULL,
+                stderr=DEVNULL,
+                check=False,
+            )
+        except Exception as acl_error:
+            logger.log(
+                level=log_levels.MODULE_DEBUG,
+                msg=f"Failed to grant ACL for run-as temp dir {work_dir} to {grant_identity}: {acl_error}",
+            )
+
+        stdout_path = remote_os.path.join(work_dir, "stdout.bin")
+        stderr_path = remote_os.path.join(work_dir, "stderr.bin")
+        return_code_path = remote_os.path.join(work_dir, "return_code.txt")
+        runner_bat_path = remote_os.path.join(work_dir, "run_command_as_user.bat")
+
+        def _read_file_bytes(path: str) -> bytes:
+            """
+            Read file content from remote host.
+
+            :param path: Remote file path.
+            :return: File content as bytes, or empty bytes if file does not exist.
+            """
+            if remote_os.path.exists(path):
+                return remote_pathlib.Path(path).read_bytes()
+            return b""
+
+        def _read_return_code(default_code: int = 1) -> int:
+            """
+            Read command return code from remote helper output file.
+
+            :param default_code: Value used if file is missing or invalid.
+            :return: Parsed integer return code.
+            """
+            if not remote_os.path.exists(return_code_path):
+                return default_code
+            raw_code = remote_pathlib.Path(return_code_path).read_text(encoding="ascii", errors="ignore").strip()
+            try:
+                return int(raw_code)
+            except ValueError:
+                return default_code
+
+        def _parse_helper_json(raw_stdout: str) -> dict[str, Any]:
+            """
+            Parse JSON emitted by helper process.
+
+            :param raw_stdout: Raw helper stdout text.
+            :return: Parsed helper payload dictionary.
+            """
+            if not raw_stdout:
+                return {}
+            try:
+                return json.loads(raw_stdout)
+            except json.JSONDecodeError:
+                lines = [line.strip() for line in raw_stdout.splitlines() if line.strip()]
+                if not lines:
+                    return {}
+                try:
+                    return json.loads(lines[-1])
+                except json.JSONDecodeError:
+                    return {"ok": False, "error": f"Invalid helper output: {raw_stdout}"}
+
+        try:
+            runner_content = (
+                "@echo off\r\n"
+                f'{command} > "{stdout_path}" 2> "{stderr_path}"\r\n'
+                f'echo %errorlevel% > "{return_code_path}"\r\n'
+            )
+            remote_pathlib.Path(runner_bat_path).write_text(runner_content, encoding="ascii", errors="ignore")
+
+            winapi_payload = {
+                "user": user,
+                "password": password,
+                "domain": domain,
+                "cwd": cwd,
+                "timeout": timeout,
+                "runner_bat_path": runner_bat_path,
+            }
+            encoded_payload = base64.b64encode(json.dumps(winapi_payload).encode("utf-8")).decode("ascii")
+
+            # Keep "no timeout" semantics when effective timeout is None.
+            helper_timeout = (timeout + 30) if timeout is not None else None
+            helper_result = remote_subprocess.run(
+                [remote_python, winapi_helper_remote_path],
+                input=encoded_payload.encode("ascii"),
+                cwd=cwd,
+                env=env,
+                shell=False,
+                stdout=PIPE,
+                stderr=PIPE,
+                check=False,
+                timeout=helper_timeout,
+            )
+
+            helper_stdout = helper_result.stdout.decode("utf-8", errors="backslashreplace").strip()
+            helper_stderr = helper_result.stderr.decode("utf-8", errors="backslashreplace")
+            helper_data = _parse_helper_json(helper_stdout)
+
+            # Prefer return code persisted by the runner script because it reflects
+            # the executed command, not the helper wrapper process.
+            return_code = _read_return_code(default_code=int(helper_data.get("returncode", 1)))
+            stdout_bytes = _read_file_bytes(stdout_path)
+            stderr_bytes = _read_file_bytes(stderr_path)
+
+            if not helper_data.get("ok", False):
+                diagnostic_parts = []
+                if helper_data.get("error"):
+                    diagnostic_parts.append(str(helper_data.get("error")))
+                if helper_stderr:
+                    diagnostic_parts.append(helper_stderr)
+                if diagnostic_parts and not stderr_bytes:
+                    stderr_bytes = "\n".join(diagnostic_parts).encode("utf-8", errors="backslashreplace")
+        finally:
+            try:
+                remote_subprocess.run(
+                    f'rmdir /S /Q "{work_dir}"',
+                    shell=True,
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                    check=False,
+                )
+            except Exception as cleanup_error:
+                logger.log(
+                    level=log_levels.MODULE_DEBUG, msg=f"Failed to cleanup run-as temp dir {work_dir}: {cleanup_error}"
+                )
+            try:
+                remote_subprocess.run(
+                    f'del /F /Q "{winapi_helper_remote_path}"',
+                    shell=True,
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                    check=False,
+                )
+            except Exception as cleanup_error:
+                logger.log(
+                    level=log_levels.MODULE_DEBUG,
+                    msg=f"Failed to cleanup run-as helper {winapi_helper_remote_path}: {cleanup_error}",
+                )
+
+        completed = CompletedProcess(
+            args=command,
+            stdout=stdout_bytes,
+            stderr=stderr_bytes,
+            returncode=return_code,
+        )
+        return self._handle_execution_outcome(
+            completed_process=completed,
+            expected_return_codes=expected_return_codes,
+            custom_exception=custom_exception,
+            skip_logging=skip_logging,
+        )
+
+    def execute_command_as_user(
+        self,
+        command: str,
+        *,
+        user: str,
+        password: str,
+        domain: str | None = None,
+        cwd: str | None = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
+        expected_return_codes: Iterable | None = frozenset({0}),
+        shell: bool = False,
+        custom_exception: Type[CalledProcessError] | None = None,
+        skip_logging: bool = False,
+    ) -> "ConnectionCompletedProcess":
+        """
+        Execute command as another user.
+
+        This method dispatches to platform-specific implementations.
+
+        :param command: Command line to execute as target user.
+        :param user: Target account user name.
+        :param password: Target account password.
+        :param domain: Account domain name; use ``None`` or ``"."`` for local account.
+        :param cwd: Working directory for launched command.
+        :param timeout: Timeout in seconds for command execution.
+        :param env: Environment variables passed to helper process.
+        :param expected_return_codes: Return codes treated as successful.
+        :param shell: Reserved for API compatibility.
+        :param custom_exception: Exception class raised for unexpected return code.
+        :param skip_logging: Skip stdout/stderr logging for this execution.
+        :return: Completed process result for executed command.
+        :raises OsNotSupported: If current OS is not supported.
+        """
+        if self._os_type == OSType.WINDOWS:
+            return self._execute_command_as_user_windows(
+                command,
+                user=user,
+                password=password,
+                domain=domain,
+                cwd=cwd,
+                timeout=timeout,
+                env=env,
+                expected_return_codes=expected_return_codes,
+                shell=shell,
+                custom_exception=custom_exception,
+                skip_logging=skip_logging,
+            )
+        raise OsNotSupported(f"Run-as-user execution is not supported for OS type: {self._os_type}")
+
+    def create_user(
+        self,
+        username: str,
+        password: str,
+        *,
+        expected_return_codes: Iterable | None = frozenset({0}),
+        custom_exception: Type[CalledProcessError] | None = None,
+        skip_logging: bool = False,
+    ) -> "ConnectionCompletedProcess":
+        """
+        Create a local system user.
+
+        This method dispatches to platform-specific implementations.
+
+        :param username: Local user name to create.
+        :param password: Initial password for the user.
+        :param expected_return_codes: Return codes considered successful.
+        :param custom_exception: Exception class raised on unexpected return code.
+        :param skip_logging: Skip stdout/stderr logging for this execution.
+        :return: Completed process result.
+        :raises OsNotSupported: If current OS is not supported.
+        """
+        return create_user_util(
+            connection=self,
+            username=username,
+            password=password,
+            expected_return_codes=expected_return_codes,
+            custom_exception=custom_exception,
+            skip_logging=skip_logging,
+        )
+
+    def delete_user(
+        self,
+        username: str,
+        *,
+        expected_return_codes: Iterable | None = frozenset({0}),
+        custom_exception: Type[CalledProcessError] | None = None,
+        skip_logging: bool = False,
+    ) -> "ConnectionCompletedProcess":
+        """
+        Delete a local system user.
+
+        This method dispatches to platform-specific implementations.
+
+        :param username: Local user name to delete.
+        :param expected_return_codes: Return codes considered successful.
+        :param custom_exception: Exception class raised on unexpected return code.
+        :param skip_logging: Skip stdout/stderr logging for this execution.
+        :return: Completed process result.
+        :raises OsNotSupported: If current OS is not supported.
+        """
+        return delete_user_util(
+            connection=self,
+            username=username,
+            expected_return_codes=expected_return_codes,
+            custom_exception=custom_exception,
+            skip_logging=skip_logging,
         )
 
     def execute_command(
@@ -889,6 +1251,12 @@ class RPyCConnection(PythonConnection):
                 raise ModuleFrameworkDesignError(f"Exception occurred while closing connection: {e}") from e
 
     def _set_process_class(self) -> None:
+        """
+        Select process wrapper class matching current remote operating system.
+
+        :return: ``None``
+        :raises OsNotSupported: If there is no matching process class.
+        """
         _os_name = self.get_os_name()
         for process_cls in self._process_classes:
             if process_cls._os_type == self._os_type:
@@ -902,6 +1270,11 @@ class RPyCConnection(PythonConnection):
             raise OsNotSupported("There is no RPyCProcess subclass for this type of OS.")
 
     def _set_bg_serving_thread(self) -> None:
+        """
+        Start background serving thread for RPyC callbacks, if enabled.
+
+        :return: ``None``
+        """
         if self._enable_bg_serving_thread:
             self._background_serving_thread = rpyc.BgServingThread(self.remote)
             time.sleep(0.1)

--- a/mfd_connect/util/account_utils.py
+++ b/mfd_connect/util/account_utils.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: MIT
+"""RPC utils for account management."""
+
+from typing import TYPE_CHECKING, Iterable, Type
+from subprocess import CalledProcessError
+
+from mfd_typing.os_values import OSType
+
+from mfd_connect.exceptions import OsNotSupported
+
+if TYPE_CHECKING:
+    from mfd_connect.base import Connection, ConnectionCompletedProcess
+
+
+def _escape_cmd_argument(value: str) -> str:
+    """Escape a value for use as a quoted ``cmd.exe`` argument."""
+    return value.replace('"', '""')
+
+
+def _build_windows_create_user_command(username: str, password: str) -> str:
+    """
+    Build a command that creates a local Windows user.
+
+    :param username: Local user name to create.
+    :param password: Initial password for the user.
+    :return: ``net user`` command for creating the user.
+    :raises ValueError: If required arguments are missing.
+    """
+    if not username:
+        raise ValueError("username is required to create a Windows user")
+    if not password:
+        raise ValueError("password is required to create a Windows user")
+
+    escaped_username = _escape_cmd_argument(username)
+    escaped_password = _escape_cmd_argument(password)
+    return f'net user "{escaped_username}" "{escaped_password}" /add'
+
+
+def _build_windows_delete_user_command(username: str) -> str:
+    """
+    Build a command that deletes a local Windows user.
+
+    :param username: Local user name to delete.
+    :return: ``net user`` command for deleting the user.
+    :raises ValueError: If required arguments are missing.
+    """
+    if not username:
+        raise ValueError("username is required to delete a Windows user")
+
+    escaped_username = _escape_cmd_argument(username)
+    return f'net user "{escaped_username}" /delete'
+
+
+def create_user(
+    connection: "Connection",
+    username: str,
+    password: str,
+    *,
+    expected_return_codes: Iterable | None = frozenset({0}),
+    custom_exception: Type[CalledProcessError] | None = None,
+    skip_logging: bool = False,
+) -> "ConnectionCompletedProcess":
+    """
+    Create a local system user on a supported platform.
+
+    :param connection: Connection used for command execution.
+    :param username: Local user name to create.
+    :param password: Initial password for the user.
+    :param expected_return_codes: Return codes considered successful.
+    :param custom_exception: Exception class raised on unexpected return code.
+    :param skip_logging: Skip stdout/stderr logging for this execution.
+    :return: Completed process result.
+    :raises OsNotSupported: If current OS is not supported.
+    """
+    if connection._os_type == OSType.WINDOWS:
+        return _create_user_windows(
+            connection=connection,
+            username=username,
+            password=password,
+            expected_return_codes=expected_return_codes,
+            custom_exception=custom_exception,
+            skip_logging=skip_logging,
+        )
+    raise OsNotSupported(f"Creating users is not supported for OS type: {connection._os_type}")
+
+
+def delete_user(
+    connection: "Connection",
+    username: str,
+    *,
+    expected_return_codes: Iterable | None = frozenset({0}),
+    custom_exception: Type[CalledProcessError] | None = None,
+    skip_logging: bool = False,
+) -> "ConnectionCompletedProcess":
+    """
+    Delete a local system user on a supported platform.
+
+    :param connection: Connection used for command execution.
+    :param username: Local user name to delete.
+    :param expected_return_codes: Return codes considered successful.
+    :param custom_exception: Exception class raised on unexpected return code.
+    :param skip_logging: Skip stdout/stderr logging for this execution.
+    :return: Completed process result.
+    :raises OsNotSupported: If current OS is not supported.
+    """
+    if connection._os_type == OSType.WINDOWS:
+        return _delete_user_windows(
+            connection=connection,
+            username=username,
+            expected_return_codes=expected_return_codes,
+            custom_exception=custom_exception,
+            skip_logging=skip_logging,
+        )
+    raise OsNotSupported(f"Deleting users is not supported for OS type: {connection._os_type}")
+
+
+def _create_user_windows(
+    *,
+    connection: "Connection",
+    username: str,
+    password: str,
+    expected_return_codes: Iterable | None,
+    custom_exception: Type[CalledProcessError] | None,
+    skip_logging: bool,
+) -> "ConnectionCompletedProcess":
+    """Create a local Windows user using ``net user``."""
+    command = _build_windows_create_user_command(username=username, password=password)
+    return connection.execute_command(
+        command,
+        shell=True,
+        expected_return_codes=expected_return_codes,
+        custom_exception=custom_exception,
+        skip_logging=skip_logging,
+    )
+
+
+def _delete_user_windows(
+    *,
+    connection: "Connection",
+    username: str,
+    expected_return_codes: Iterable | None,
+    custom_exception: Type[CalledProcessError] | None,
+    skip_logging: bool,
+) -> "ConnectionCompletedProcess":
+    """Delete a local Windows user using ``net user``."""
+    command = _build_windows_delete_user_command(username=username)
+    return connection.execute_command(
+        command,
+        shell=True,
+        expected_return_codes=expected_return_codes,
+        custom_exception=custom_exception,
+        skip_logging=skip_logging,
+    )

--- a/mfd_connect/util/runas_winapi_script.py
+++ b/mfd_connect/util/runas_winapi_script.py
@@ -1,0 +1,395 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: MIT
+"""Run command as another Windows user using CreateProcessWithLogonW."""
+
+import base64
+import ctypes
+import ctypes.wintypes as wintypes
+import json
+import sys
+from typing import Any
+
+LOGON_WITH_PROFILE = 0x00000001
+CREATE_UNICODE_ENVIRONMENT = 0x00000400
+CREATE_NO_WINDOW = 0x08000000
+WAIT_TIMEOUT = 0x00000102
+INFINITE = 0xFFFFFFFF
+
+# Window Station / Desktop ACL constants
+WINSTA_ALL_ACCESS = 0x000F037F
+DESKTOP_ALL_ACCESS = 0x001F01FF
+DACL_SECURITY_INFORMATION = 0x4
+SE_KERNEL_OBJECT = 6
+ACL_REVISION = 2
+CONTAINER_INHERIT_ACE = 0x2
+INHERIT_ONLY_ACE = 0x8
+NO_PROPAGATE_INHERIT_ACE = 0x4
+
+
+def _get_user_sid(username: str, domain: str | None) -> bytes | None:
+    """
+    Resolve account SID.
+
+    :param username: Account user name.
+    :param domain: Account domain name or ``None`` for local lookup.
+    :return: Raw SID bytes if account was resolved, otherwise ``None``.
+    """
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    name = f"{domain}\\{username}" if domain and domain not in (".", "") else username
+    sid_size = wintypes.DWORD(0)
+    dom_size = wintypes.DWORD(0)
+    sid_use = wintypes.DWORD(0)
+    # First call: retrieve required buffer sizes
+    advapi32.LookupAccountNameW(
+        None, name, None, ctypes.byref(sid_size), None, ctypes.byref(dom_size), ctypes.byref(sid_use)
+    )
+    if not sid_size.value:
+        return None
+    sid_buf = ctypes.create_string_buffer(sid_size.value)
+    dom_buf = ctypes.create_unicode_buffer(dom_size.value)
+    if not advapi32.LookupAccountNameW(
+        None, name, sid_buf, ctypes.byref(sid_size), dom_buf, ctypes.byref(dom_size), ctypes.byref(sid_use)
+    ):
+        return None
+    return bytes(sid_buf)
+
+
+def _add_ace_to_object(handle: int, se_object_type: int, sid: bytes, access_mask: int, ace_flags: int) -> None:
+    """
+    Append an allow ACE to the DACL of a kernel object.
+
+    :param handle: Handle to the kernel object.
+    :param se_object_type: Security object type used by ``GetSecurityInfo``.
+    :param sid: Account SID in raw bytes.
+    :param access_mask: Access rights mask for the ACE.
+    :param ace_flags: ACE inheritance/propagation flags.
+    :return: ``None``
+    """
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    # Retrieve current DACL + security descriptor
+    p_old_dacl = ctypes.c_void_p()
+    p_sd = ctypes.c_void_p()
+    rc = advapi32.GetSecurityInfo(
+        handle,
+        se_object_type,
+        DACL_SECURITY_INFORMATION,
+        None,
+        None,
+        ctypes.byref(p_old_dacl),
+        None,
+        ctypes.byref(p_sd),
+    )
+    if rc != 0:
+        return
+
+    try:
+        # How many bytes is the old DACL?
+        class _AclSizeInfo(ctypes.Structure):
+            """ACL size information returned by ``GetAclInformation``."""
+
+            _fields_ = [
+                ("AceCount", wintypes.DWORD),
+                ("AclBytesInUse", wintypes.DWORD),
+                ("AclBytesFree", wintypes.DWORD),
+            ]
+
+        old_info = _AclSizeInfo()
+        if p_old_dacl:
+            advapi32.GetAclInformation(p_old_dacl, ctypes.byref(old_info), ctypes.sizeof(old_info), 2)
+        bytes_used = old_info.AclBytesInUse or 8  # 8 = empty ACL header
+
+        # Allocate a new ACL: existing bytes + one new ACE (header 8 + SID length)
+        new_acl_size = bytes_used + 8 + len(sid)
+        new_acl = ctypes.create_string_buffer(new_acl_size)
+        if not advapi32.InitializeAcl(new_acl, new_acl_size, ACL_REVISION):
+            return
+
+        # Copy existing ACEs into the new ACL
+        for i in range(old_info.AceCount):
+            p_ace = ctypes.c_void_p()
+            if advapi32.GetAce(p_old_dacl, i, ctypes.byref(p_ace)):
+                # ACE layout: BYTE AceType, BYTE AceFlags, WORD AceSize …
+                ace_size = ctypes.cast(p_ace, ctypes.POINTER(ctypes.c_ushort * 4))[0][1]
+                advapi32.AddAce(new_acl, ACL_REVISION, 0xFFFFFFFF, p_ace, ace_size)
+
+        # Append the new access-allowed ACE
+        advapi32.AddAccessAllowedAceEx(new_acl, ACL_REVISION, ace_flags, access_mask, sid)
+
+        # Write the updated DACL back to the object
+        advapi32.SetSecurityInfo(handle, se_object_type, DACL_SECURITY_INFORMATION, None, None, new_acl, None)
+    finally:
+        kernel32.LocalFree(p_sd)
+
+
+def _get_current_desktop_str() -> str | None:
+    r"""
+    Return current window station and desktop name.
+
+    :return: ``WinStaName\\DesktopName`` for current process/thread, or ``None``.
+    """
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    UOI_NAME = 2
+
+    hwinsta = user32.GetProcessWindowStation()
+    if not hwinsta:
+        return None
+    buf = ctypes.create_unicode_buffer(512)
+    length = wintypes.DWORD(0)
+    user32.GetUserObjectInformationW(hwinsta, UOI_NAME, buf, ctypes.sizeof(buf), ctypes.byref(length))
+    winsta_name = buf.value
+
+    hdesktop = user32.GetThreadDesktop(kernel32.GetCurrentThreadId())
+    if not hdesktop:
+        return winsta_name
+    user32.GetUserObjectInformationW(hdesktop, UOI_NAME, buf, ctypes.sizeof(buf), ctypes.byref(length))
+    desktop_name = buf.value
+
+    return f"{winsta_name}\\{desktop_name}" if desktop_name else winsta_name
+
+
+def _grant_winsta_desktop(username: str, domain: str | None) -> list[str]:
+    """
+    Grant account access to current window station and desktop.
+
+    Uses ``GetProcessWindowStation()``/``GetThreadDesktop()`` (no access check)
+    rather than ``OpenWindowStationW("WinSta0", ...)`` which fails with
+    ERROR_ACCESS_DENIED when the caller runs in a non-interactive session.
+
+    Without this grant, child processes spawned by cmd.exe (running as *user*
+    via ``CreateProcessWithLogonW``) crash with STATUS_DLL_INIT_FAILED
+    (0xC0000142) because user32.dll cannot attach to the window station.
+
+    :param username: Target account user name.
+    :param domain: Target account domain or ``None`` for local account.
+    :return: Diagnostic messages describing performed steps and failures.
+    """
+    diag: list[str] = []
+    sid = _get_user_sid(username, domain)
+    if not sid:
+        error_code = ctypes.get_last_error()
+        diag.append(f"_get_user_sid failed: winerror={error_code}")
+        return diag
+    diag.append(f"got SID, len={len(sid)}")
+
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    # GetProcessWindowStation returns a pseudo-handle; no permission check needed.
+    hwinsta = user32.GetProcessWindowStation()
+    if hwinsta:
+        UOI_NAME = 2
+        buf = ctypes.create_unicode_buffer(512)
+        user32.GetUserObjectInformationW(hwinsta, UOI_NAME, buf, ctypes.sizeof(buf), None)
+        diag.append(f"current WinSta: '{buf.value}'")
+        _add_ace_to_object(hwinsta, SE_KERNEL_OBJECT, sid, WINSTA_ALL_ACCESS, CONTAINER_INHERIT_ACE | INHERIT_ONLY_ACE)
+        _add_ace_to_object(hwinsta, SE_KERNEL_OBJECT, sid, WINSTA_ALL_ACCESS, NO_PROPAGATE_INHERIT_ACE)
+        diag.append("WinSta ACEs added")
+    else:
+        diag.append(f"GetProcessWindowStation failed: winerror={ctypes.get_last_error()}")
+
+    hdesktop = user32.GetThreadDesktop(kernel32.GetCurrentThreadId())
+    if hdesktop:
+        buf2 = ctypes.create_unicode_buffer(512)
+        user32.GetUserObjectInformationW(hdesktop, 2, buf2, ctypes.sizeof(buf2), None)
+        diag.append(f"current Desktop: '{buf2.value}'")
+        _add_ace_to_object(hdesktop, SE_KERNEL_OBJECT, sid, DESKTOP_ALL_ACCESS, 0)
+        diag.append("Desktop ACE added")
+    else:
+        diag.append(f"GetThreadDesktop failed: winerror={ctypes.get_last_error()}")
+
+    return diag
+
+
+class STARTUPINFOW(ctypes.Structure):
+    """ctypes mapping of WinAPI ``STARTUPINFOW`` structure."""
+
+    _fields_ = [
+        ("cb", wintypes.DWORD),
+        ("lpReserved", wintypes.LPWSTR),
+        ("lpDesktop", wintypes.LPWSTR),
+        ("lpTitle", wintypes.LPWSTR),
+        ("dwX", wintypes.DWORD),
+        ("dwY", wintypes.DWORD),
+        ("dwXSize", wintypes.DWORD),
+        ("dwYSize", wintypes.DWORD),
+        ("dwXCountChars", wintypes.DWORD),
+        ("dwYCountChars", wintypes.DWORD),
+        ("dwFillAttribute", wintypes.DWORD),
+        ("dwFlags", wintypes.DWORD),
+        ("wShowWindow", wintypes.WORD),
+        ("cbReserved2", wintypes.WORD),
+        ("lpReserved2", ctypes.POINTER(ctypes.c_ubyte)),
+        ("hStdInput", wintypes.HANDLE),
+        ("hStdOutput", wintypes.HANDLE),
+        ("hStdError", wintypes.HANDLE),
+    ]
+
+
+class PROCESS_INFORMATION(ctypes.Structure):
+    """ctypes mapping of WinAPI ``PROCESS_INFORMATION`` structure."""
+
+    _fields_ = [
+        ("hProcess", wintypes.HANDLE),
+        ("hThread", wintypes.HANDLE),
+        ("dwProcessId", wintypes.DWORD),
+        ("dwThreadId", wintypes.DWORD),
+    ]
+
+
+def _last_error_payload(prefix: str) -> dict[str, Any]:
+    """
+    Build JSON-serializable error payload from ``GetLastError``.
+
+    :param prefix: Error context prefix.
+    :return: Payload containing ``ok``, ``winerror`` and ``error`` keys.
+    """
+    error_code = ctypes.get_last_error()
+    try:
+        error_text = ctypes.WinError(error_code).strerror
+    except Exception:
+        error_text = "unknown error"
+    return {"ok": False, "winerror": int(error_code), "error": f"{prefix}: [{error_code}] {error_text}"}
+
+
+def _setup_winapi() -> tuple[Any, Any]:
+    """
+    Configure required WinAPI function signatures.
+
+    :return: Tuple ``(kernel32, advapi32)`` DLL handles with configured prototypes.
+    """
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+
+    advapi32.CreateProcessWithLogonW.argtypes = [
+        wintypes.LPCWSTR,  # lpUsername
+        wintypes.LPCWSTR,  # lpDomain
+        wintypes.LPCWSTR,  # lpPassword
+        wintypes.DWORD,  # dwLogonFlags
+        wintypes.LPCWSTR,  # lpApplicationName
+        wintypes.LPWSTR,  # lpCommandLine (mutable)
+        wintypes.DWORD,  # dwCreationFlags
+        wintypes.LPVOID,  # lpEnvironment
+        wintypes.LPCWSTR,  # lpCurrentDirectory
+        ctypes.POINTER(STARTUPINFOW),  # lpStartupInfo
+        ctypes.POINTER(PROCESS_INFORMATION),  # lpProcessInformation
+    ]
+    advapi32.CreateProcessWithLogonW.restype = wintypes.BOOL
+
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+
+    kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+
+    kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    kernel32.TerminateProcess.restype = wintypes.BOOL
+
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    return kernel32, advapi32
+
+
+def main() -> int:
+    """
+    Execute payload-driven process creation flow.
+
+    :return: Process exit code for the helper wrapper.
+    """
+    stdin_payload = sys.stdin.read().strip()
+    argv_payload = sys.argv[1].strip() if len(sys.argv) == 2 else ""
+    encoded_payload = stdin_payload or argv_payload
+
+    if not encoded_payload:
+        print(json.dumps({"ok": False, "error": "Expected base64 payload via stdin or argv"}))
+        return 2
+
+    try:
+        payload = json.loads(base64.b64decode(encoded_payload).decode("utf-8"))
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": f"Failed to decode payload: {exc}"}))
+        return 2
+
+    username: str = payload["user"]
+    password: str = payload["password"]
+    domain: str | None = payload.get("domain")
+    cwd: str | None = payload.get("cwd")
+    timeout = payload.get("timeout")
+    runner_bat_path: str = payload["runner_bat_path"]
+
+    # command_line must be a mutable LPWSTR buffer - Windows may modify it in place.
+    # Redirections are already inside runner_bat_path; just run the bat directly.
+    command_line_str = f'cmd.exe /c "{runner_bat_path}"'
+    command_line_buf = ctypes.create_unicode_buffer(command_line_str)
+
+    startup_info = STARTUPINFOW()
+    startup_info.cb = ctypes.sizeof(STARTUPINFOW)
+    process_info = PROCESS_INFORMATION()
+
+    kernel32, advapi32 = _setup_winapi()
+
+    # Use None for domain when caller passed "." to mean local machine
+    effective_domain = None if domain in (".", "") else domain
+
+    # Grant the target user access to the caller's Window Station and Desktop.
+    # Without this, child processes crash with STATUS_DLL_INIT_FAILED (0xC0000142).
+    # Uses GetProcessWindowStation (no ACL check) rather than OpenWindowStationW.
+    winsta_diag = _grant_winsta_desktop(username, effective_domain)
+
+    # Use the caller's actual desktop so the target user uses the same station
+    # that we just granted them access to.
+    current_desktop = _get_current_desktop_str()
+    if current_desktop:
+        startup_info.lpDesktop = current_desktop
+        winsta_diag.append(f"lpDesktop={current_desktop}")
+
+    created = advapi32.CreateProcessWithLogonW(
+        username,
+        effective_domain,
+        password,
+        LOGON_WITH_PROFILE,
+        None,  # lpApplicationName - None, full path in command_line
+        command_line_buf,  # lpCommandLine - mutable buffer
+        CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW,
+        None,  # inherit current environment
+        cwd,
+        ctypes.byref(startup_info),
+        ctypes.byref(process_info),
+    )
+
+    if not created:
+        result = _last_error_payload("CreateProcessWithLogonW failed")
+        result["debug"] = {
+            "username": username,
+            "domain": effective_domain,
+            "command_line": command_line_str,
+            "cwd": cwd,
+        }
+        print(json.dumps(result))
+        return 0
+
+    try:
+        timeout_ms = INFINITE if timeout is None else int(timeout * 1000)
+        wait_result = kernel32.WaitForSingleObject(process_info.hProcess, timeout_ms)
+        if wait_result == WAIT_TIMEOUT:
+            kernel32.TerminateProcess(process_info.hProcess, 124)
+            print(json.dumps({"ok": False, "timeout": True, "returncode": 124}))
+            return 0
+
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(process_info.hProcess, ctypes.byref(exit_code)):
+            print(json.dumps(_last_error_payload("GetExitCodeProcess failed")))
+            return 0
+
+        print(json.dumps({"ok": True, "returncode": int(exit_code.value)}))
+        return 0
+    finally:
+        kernel32.CloseHandle(process_info.hThread)
+        kernel32.CloseHandle(process_info.hProcess)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_mfd_connect/test_rpyc.py
+++ b/tests/unit/test_mfd_connect/test_rpyc.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 import subprocess
 import time
+import types
 from pathlib import Path
 from subprocess import CompletedProcess, CalledProcessError
 from unittest.mock import patch
@@ -16,7 +17,9 @@ from mfd_connect.base import ConnectionCompletedProcess
 from mfd_connect.exceptions import (
     ConnectionCalledProcessError,
     ModuleFrameworkDesignError,
+    OsNotSupported,
     RPyCDeploymentException,
+    RunAsUserError,
 )
 from mfd_connect.process.rpyc import PosixRPyCProcess, WindowsRPyCProcess, ESXiRPyCProcess
 
@@ -257,6 +260,346 @@ class TestRPyCConnection:
             shell=False,
             stderr_to_stdout=False,
             timeout=None,
+        )
+
+    def test_ensure_remote_winapi_helper_missing_local_script(self, rpyc, mocker):
+        mocker.patch("mfd_connect.rpyc.Path.exists", return_value=False)
+        with pytest.raises(RunAsUserError, match="WinAPI helper script not found"):
+            rpyc._ensure_remote_winapi_helper()
+
+    def test_ensure_remote_winapi_helper_uploads_script(self, rpyc, mocker):
+        mocker.patch("mfd_connect.rpyc.Path.exists", return_value=True)
+        mocker.patch("mfd_connect.rpyc.Path.read_text", return_value="print('ok')")
+
+        remote_os = mocker.Mock()
+        remote_os.path.join.side_effect = lambda *parts: "\\".join(parts)
+        remote_tempfile = mocker.Mock()
+        remote_tempfile.gettempdir.return_value = "C:\\Temp"
+        remote_tempfile.mkstemp.return_value = (11, "C:\\Temp\\mfd_connect\\runas.py")
+        remote_pathlib = mocker.Mock()
+        remote_modules = mocker.Mock(os=remote_os, tempfile=remote_tempfile, pathlib=remote_pathlib)
+        rpyc.modules = mocker.Mock(return_value=remote_modules)
+
+        remote_path = mocker.Mock()
+        remote_pathlib.Path.return_value = remote_path
+
+        helper_path = rpyc._ensure_remote_winapi_helper()
+
+        assert helper_path == "C:\\Temp\\mfd_connect\\runas.py"
+        remote_pathlib.Path.assert_any_call("C:\\Temp\\mfd_connect")
+        remote_pathlib.Path.assert_any_call("C:\\Temp\\mfd_connect\\runas.py")
+        remote_os.close.assert_called_once_with(11)
+        remote_path.write_text.assert_called_once_with("print('ok')", encoding="utf-8")
+
+    def test_execute_command_as_user_dispatch_windows(self, rpyc, mocker):
+        rpyc._os_type = OSType.WINDOWS
+        rpyc._execute_command_as_user_windows = mocker.Mock(return_value="done")
+
+        result = rpyc.execute_command_as_user(command="whoami", user="john", password="pwd")
+
+        assert result == "done"
+        rpyc._execute_command_as_user_windows.assert_called_once()
+
+    def test_execute_command_as_user_not_supported(self, rpyc):
+        rpyc._os_type = OSType.POSIX
+        with pytest.raises(OsNotSupported, match="Run-as-user execution is not supported"):
+            rpyc.execute_command_as_user(command="whoami", user="john", password="pwd")
+
+    def test_execute_command_as_user_windows_success_flow(self, rpyc, mocker):
+        rpyc._os_type = OSType.WINDOWS
+        rpyc._ip = "10.10.10.10"
+        rpyc._default_timeout = 11
+        rpyc._ensure_remote_winapi_helper = mocker.Mock(return_value="C:\\Temp\\runas.py")
+
+        path_objects = {}
+        file_bytes = {
+            "C:\\Users\\john\\AppData\\Local\\Temp\\mfd_runas_1\\stdout.bin": b"std-out",
+            "C:\\Users\\john\\AppData\\Local\\Temp\\mfd_runas_1\\stderr.bin": b"",
+        }
+
+        def _path_object(path):
+            if path not in path_objects:
+                obj = mocker.Mock()
+                obj.write_text = mocker.Mock()
+                obj.read_bytes = mocker.Mock(side_effect=lambda: file_bytes.get(path, b""))
+                obj.read_text = mocker.Mock(return_value="3")
+                path_objects[path] = obj
+            return path_objects[path]
+
+        remote_os = mocker.Mock()
+        remote_os.path.join.side_effect = lambda *parts: "\\".join(parts)
+        remote_os.path.isdir.return_value = True
+        remote_os.path.exists.side_effect = lambda p: p in file_bytes
+        remote_os.environ = {"SystemRoot": "C:\\Windows"}
+
+        remote_tempfile = mocker.Mock()
+        remote_tempfile.mkdtemp.return_value = "C:\\Users\\john\\AppData\\Local\\Temp\\mfd_runas_1"
+
+        remote_pathlib = mocker.Mock()
+        remote_pathlib.Path.side_effect = _path_object
+
+        def _run_side_effect(cmd, **_kwargs):
+            if isinstance(cmd, list) and cmd[0] == "python.exe":
+                return CompletedProcess(args=cmd, returncode=0, stdout=b'{"ok": true, "returncode": 3}', stderr=b"")
+            return CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+        remote_subprocess = mocker.Mock()
+        remote_subprocess.run.side_effect = _run_side_effect
+
+        remote_modules = types.SimpleNamespace(
+            tempfile=remote_tempfile,
+            os=remote_os,
+            pathlib=remote_pathlib,
+            subprocess=remote_subprocess,
+            sys=types.SimpleNamespace(executable="python.exe"),
+        )
+        rpyc.modules = mocker.Mock(return_value=remote_modules)
+        rpyc._handle_execution_outcome = mocker.Mock(return_value="handled")
+
+        command = 'echo "hello world"'
+        result = rpyc._execute_command_as_user_windows(
+            command=command,
+            user="john",
+            password="secret",
+            domain=".",
+            env={"A": "B"},
+            timeout=None,
+            expected_return_codes={0, 3},
+        )
+
+        assert result == "handled"
+        completed_process = rpyc._handle_execution_outcome.call_args.kwargs["completed_process"]
+        assert completed_process.returncode == 3
+        assert completed_process.stdout == b"std-out"
+        assert completed_process.stderr == b""
+
+        runner_bat_path = "C:\\Users\\john\\AppData\\Local\\Temp\\mfd_runas_1\\run_command_as_user.bat"
+        runner_call = path_objects[runner_bat_path].write_text.call_args.args[0]
+        assert command in runner_call
+        assert "cmd.exe /d /s /c" not in runner_call
+
+        helper_call = next(
+            call
+            for call in remote_subprocess.run.call_args_list
+            if call.args and isinstance(call.args[0], list) and call.args[0][0] == "python.exe"
+        )
+        assert len(helper_call.args[0]) == 2
+        assert "stdin" not in helper_call.kwargs
+        assert isinstance(helper_call.kwargs["input"], bytes)
+
+    def test_execute_command_as_user_windows_helper_error_falls_back_to_stderr(self, rpyc, mocker):
+        rpyc._os_type = OSType.WINDOWS
+        rpyc._ip = "10.10.10.10"
+        rpyc._ensure_remote_winapi_helper = mocker.Mock(return_value="C:\\Temp\\runas.py")
+
+        path_objects = {}
+
+        def _path_object(path):
+            if path not in path_objects:
+                obj = mocker.Mock()
+                obj.write_text = mocker.Mock()
+                obj.read_bytes = mocker.Mock(return_value=b"")
+                obj.read_text = mocker.Mock(return_value="not-an-int")
+                path_objects[path] = obj
+            return path_objects[path]
+
+        remote_os = mocker.Mock()
+        remote_os.path.join.side_effect = lambda *parts: "\\".join(parts)
+        remote_os.path.isdir.return_value = False
+        remote_os.path.exists.return_value = False
+        remote_os.environ = {"SystemRoot": "C:\\Windows"}
+
+        remote_tempfile = mocker.Mock()
+        remote_tempfile.mkdtemp.return_value = "C:\\Windows\\Temp\\mfd_runas_2"
+
+        remote_pathlib = mocker.Mock()
+        remote_pathlib.Path.side_effect = _path_object
+
+        def _run_side_effect(cmd, **_kwargs):
+            if isinstance(cmd, list) and cmd[0] == "python.exe":
+                payload = b'{"ok": false, "error": "CreateProcessWithLogonW failed"}'
+                return CompletedProcess(args=cmd, returncode=0, stdout=payload, stderr=b"helper stderr")
+            return CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+        remote_subprocess = mocker.Mock()
+        remote_subprocess.run.side_effect = _run_side_effect
+
+        remote_modules = types.SimpleNamespace(
+            tempfile=remote_tempfile,
+            os=remote_os,
+            pathlib=remote_pathlib,
+            subprocess=remote_subprocess,
+            sys=types.SimpleNamespace(executable="python.exe"),
+        )
+        rpyc.modules = mocker.Mock(return_value=remote_modules)
+        rpyc._handle_execution_outcome = mocker.Mock(return_value="handled")
+
+        rpyc._execute_command_as_user_windows(
+            command="echo hello",
+            user="john",
+            password="secret",
+            timeout=1,
+            expected_return_codes=None,
+        )
+
+        completed_process = rpyc._handle_execution_outcome.call_args.kwargs["completed_process"]
+        assert completed_process.returncode == 1
+        assert b"CreateProcessWithLogonW failed" in completed_process.stderr
+        assert b"helper stderr" in completed_process.stderr
+
+    def test_execute_command_as_user_windows_prefers_runner_return_code_file(self, rpyc, mocker):
+        rpyc._os_type = OSType.WINDOWS
+        rpyc._ip = "10.10.10.10"
+        rpyc._default_timeout = 11
+        rpyc._ensure_remote_winapi_helper = mocker.Mock(return_value="C:\\Temp\\runas.py")
+
+        path_objects = {}
+
+        def _path_object(path):
+            if path not in path_objects:
+                obj = mocker.Mock()
+                obj.write_text = mocker.Mock()
+                obj.read_bytes = mocker.Mock(return_value=b"Administrator privileges are needed to run application.")
+                obj.read_text = mocker.Mock(return_value="1")
+                path_objects[path] = obj
+            return path_objects[path]
+
+        remote_os = mocker.Mock()
+        remote_os.path.join.side_effect = lambda *parts: "\\".join(parts)
+        remote_os.path.isdir.return_value = True
+
+        def _exists_side_effect(path):
+            return path.endswith("stdout.bin") or path.endswith("stderr.bin") or path.endswith("return_code.txt")
+
+        remote_os.path.exists.side_effect = _exists_side_effect
+        remote_os.environ = {"SystemRoot": "C:\\Windows"}
+
+        remote_tempfile = mocker.Mock()
+        remote_tempfile.mkdtemp.return_value = "C:\\Users\\john\\AppData\\Local\\Temp\\mfd_runas_4"
+
+        remote_pathlib = mocker.Mock()
+        remote_pathlib.Path.side_effect = _path_object
+
+        def _run_side_effect(cmd, **_kwargs):
+            if isinstance(cmd, list) and cmd[0] == "python.exe":
+                # Helper wrapper exits successfully but command rc persisted in file is 1.
+                return CompletedProcess(args=cmd, returncode=0, stdout=b'{"ok": true, "returncode": 0}', stderr=b"")
+            return CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+        remote_subprocess = mocker.Mock()
+        remote_subprocess.run.side_effect = _run_side_effect
+
+        remote_modules = types.SimpleNamespace(
+            tempfile=remote_tempfile,
+            os=remote_os,
+            pathlib=remote_pathlib,
+            subprocess=remote_subprocess,
+            sys=types.SimpleNamespace(executable="python.exe"),
+        )
+        rpyc.modules = mocker.Mock(return_value=remote_modules)
+        rpyc._handle_execution_outcome = mocker.Mock(return_value="handled")
+
+        rpyc._execute_command_as_user_windows(
+            command=r"C:\\NVMUPDATE\\Winx64\\nvmupdatew64e.exe -i -l",
+            user="john",
+            password="secret",
+            domain=".",
+            timeout=60,
+            expected_return_codes={0, 1},
+        )
+
+        completed_process = rpyc._handle_execution_outcome.call_args.kwargs["completed_process"]
+        assert completed_process.returncode == 1
+
+    def test_execute_command_as_user_windows_no_timeout_keeps_helper_unbounded(self, rpyc, mocker):
+        rpyc._os_type = OSType.WINDOWS
+        rpyc._ip = "10.10.10.10"
+        rpyc._default_timeout = None
+        rpyc._ensure_remote_winapi_helper = mocker.Mock(return_value="C:\\Temp\\runas.py")
+
+        path_objects = {}
+
+        def _path_object(path):
+            if path not in path_objects:
+                obj = mocker.Mock()
+                obj.write_text = mocker.Mock()
+                obj.read_bytes = mocker.Mock(return_value=b"")
+                obj.read_text = mocker.Mock(return_value="0")
+                path_objects[path] = obj
+            return path_objects[path]
+
+        remote_os = mocker.Mock()
+        remote_os.path.join.side_effect = lambda *parts: "\\".join(parts)
+        remote_os.path.isdir.return_value = True
+        remote_os.path.exists.return_value = False
+        remote_os.environ = {"SystemRoot": "C:\\Windows"}
+
+        remote_tempfile = mocker.Mock()
+        remote_tempfile.mkdtemp.return_value = "C:\\Users\\john\\AppData\\Local\\Temp\\mfd_runas_3"
+
+        remote_pathlib = mocker.Mock()
+        remote_pathlib.Path.side_effect = _path_object
+
+        def _run_side_effect(cmd, **_kwargs):
+            if isinstance(cmd, list) and cmd[0] == "python.exe":
+                return CompletedProcess(args=cmd, returncode=0, stdout=b'{"ok": true, "returncode": 0}', stderr=b"")
+            return CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+        remote_subprocess = mocker.Mock()
+        remote_subprocess.run.side_effect = _run_side_effect
+
+        remote_modules = types.SimpleNamespace(
+            tempfile=remote_tempfile,
+            os=remote_os,
+            pathlib=remote_pathlib,
+            subprocess=remote_subprocess,
+            sys=types.SimpleNamespace(executable="python.exe"),
+        )
+        rpyc.modules = mocker.Mock(return_value=remote_modules)
+        rpyc._handle_execution_outcome = mocker.Mock(return_value="handled")
+
+        rpyc._execute_command_as_user_windows(
+            command="echo hello",
+            user="john",
+            password="secret",
+            timeout=None,
+            expected_return_codes={0},
+        )
+
+        helper_call = next(
+            call
+            for call in remote_subprocess.run.call_args_list
+            if call.args and isinstance(call.args[0], list) and call.args[0][0] == "python.exe"
+        )
+        assert helper_call.kwargs["timeout"] is None
+
+    def test_create_user_delegates_to_utility(self, rpyc, mocker):
+        util_call = mocker.patch("mfd_connect.rpyc.create_user_util", return_value="created")
+
+        result = rpyc.create_user("john", "pwd")
+
+        assert result == "created"
+        util_call.assert_called_once_with(
+            connection=rpyc,
+            username="john",
+            password="pwd",
+            expected_return_codes=frozenset({0}),
+            custom_exception=None,
+            skip_logging=False,
+        )
+
+    def test_delete_user_delegates_to_utility(self, rpyc, mocker):
+        util_call = mocker.patch("mfd_connect.rpyc.delete_user_util", return_value="deleted")
+
+        result = rpyc.delete_user("john")
+
+        assert result == "deleted"
+        util_call.assert_called_once_with(
+            connection=rpyc,
+            username="john",
+            expected_return_codes=frozenset({0}),
+            custom_exception=None,
+            skip_logging=False,
         )
 
     @pytest.fixture()

--- a/tests/unit/test_mfd_connect/test_utils/test_account_utils.py
+++ b/tests/unit/test_mfd_connect/test_utils/test_account_utils.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: MIT
+
+import pytest
+from mfd_typing.os_values import OSType
+
+from mfd_connect.exceptions import OsNotSupported
+from mfd_connect.util import account_utils
+
+
+class DummyConnection:
+    def __init__(self, os_type):
+        """Initialize a dummy connection that simulates the behavior of a real connection for testing purposes."""
+        self._os_type = os_type
+        self.execute_command_calls = []
+
+    def execute_command(self, *args, **kwargs):
+        self.execute_command_calls.append((args, kwargs))
+        return "ok"
+
+
+class TestAccountUtils:
+    def test_escape_cmd_argument(self):
+        assert account_utils._escape_cmd_argument('a"b') == 'a""b'
+
+    def test_build_windows_create_user_command(self):
+        command = account_utils._build_windows_create_user_command('user"name', 'pass"word')
+        assert command == 'net user "user""name" "pass""word" /add'
+
+    @pytest.mark.parametrize(
+        "username,password,error",
+        [
+            ("", "pwd", "username is required to create a Windows user"),
+            ("user", "", "password is required to create a Windows user"),
+        ],
+    )
+    def test_build_windows_create_user_command_validation(self, username, password, error):
+        with pytest.raises(ValueError, match=error):
+            account_utils._build_windows_create_user_command(username, password)
+
+    def test_build_windows_delete_user_command(self):
+        command = account_utils._build_windows_delete_user_command('user"name')
+        assert command == 'net user "user""name" /delete'
+
+    def test_build_windows_delete_user_command_validation(self):
+        with pytest.raises(ValueError, match="username is required to delete a Windows user"):
+            account_utils._build_windows_delete_user_command("")
+
+    def test_create_user_windows_dispatch(self):
+        connection = DummyConnection(OSType.WINDOWS)
+        result = account_utils.create_user(connection=connection, username="john", password="pwd")
+
+        assert result == "ok"
+        assert len(connection.execute_command_calls) == 1
+        args, kwargs = connection.execute_command_calls[0]
+        assert args[0] == 'net user "john" "pwd" /add'
+        assert kwargs["shell"] is True
+
+    def test_delete_user_windows_dispatch(self):
+        connection = DummyConnection(OSType.WINDOWS)
+        result = account_utils.delete_user(connection=connection, username="john")
+
+        assert result == "ok"
+        assert len(connection.execute_command_calls) == 1
+        args, kwargs = connection.execute_command_calls[0]
+        assert args[0] == 'net user "john" /delete'
+        assert kwargs["shell"] is True
+
+    @pytest.mark.parametrize("function_call", ["create", "delete"])
+    def test_user_management_not_supported(self, function_call):
+        connection = DummyConnection(OSType.POSIX)
+
+        with pytest.raises(OsNotSupported):
+            if function_call == "create":
+                account_utils.create_user(connection=connection, username="john", password="pwd")
+            else:
+                account_utils.delete_user(connection=connection, username="john")

--- a/tests/unit/test_mfd_connect/test_utils/test_runas_winapi_script.py
+++ b/tests/unit/test_mfd_connect/test_utils/test_runas_winapi_script.py
@@ -1,0 +1,367 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: MIT
+
+import base64
+import json
+
+from mfd_connect.util import runas_winapi_script as script
+
+
+def _encode_payload(payload):
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+
+
+class _FakeFunction:
+    def __init__(self, return_value=True, side_effect=None):
+        self.return_value = return_value
+        self.side_effect = side_effect
+        self.argtypes = None
+        self.restype = None
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self.side_effect is not None:
+            return self.side_effect(*args, **kwargs)
+        return self.return_value
+
+
+class _FakeKernel32:
+    def __init__(self, wait_result=0, exit_code=0):
+        self.WaitForSingleObject = _FakeFunction(return_value=wait_result)
+        self.TerminateProcess = _FakeFunction(return_value=True)
+        self.CloseHandle = _FakeFunction(return_value=True)
+        self._exit_code = exit_code
+
+        def _get_exit_code(_process, ptr):
+            ptr._obj.value = self._exit_code
+            return True
+
+        self.GetExitCodeProcess = _FakeFunction(side_effect=_get_exit_code)
+
+
+class _FakeAdvapi32:
+    def __init__(self, created=True):
+        self.CreateProcessWithLogonW = _FakeFunction(return_value=created)
+
+
+class TestRunAsWinapiScript:
+    def test_last_error_payload(self, monkeypatch):
+        monkeypatch.setattr(script.ctypes, "get_last_error", lambda: 5, raising=False)
+
+        class _FakeWinError:
+            def __init__(self, _code):
+                self.strerror = "Access is denied"
+
+        monkeypatch.setattr(script.ctypes, "WinError", _FakeWinError, raising=False)
+
+        result = script._last_error_payload("prefix")
+
+        assert result["ok"] is False
+        assert result["winerror"] == 5
+        assert "prefix" in result["error"]
+
+    def test_last_error_payload_when_winerror_raises(self, monkeypatch):
+        monkeypatch.setattr(script.ctypes, "get_last_error", lambda: 77, raising=False)
+
+        def _raise_winerror(_code):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(script.ctypes, "WinError", _raise_winerror, raising=False)
+
+        result = script._last_error_payload("prefix")
+
+        assert result["ok"] is False
+        assert result["winerror"] == 77
+        assert "unknown error" in result["error"]
+
+    def test_get_user_sid_returns_none_when_lookup_size_missing(self, monkeypatch):
+        class _Advapi32:
+            def LookupAccountNameW(self, *_args):
+                return False
+
+        monkeypatch.setattr(script.ctypes, "WinDLL", lambda *_args, **_kwargs: _Advapi32(), raising=False)
+
+        assert script._get_user_sid("john", None) is None
+
+    def test_get_user_sid_returns_sid_bytes(self, monkeypatch):
+        class _Advapi32:
+            def __init__(self):
+                self.calls = 0
+
+            def LookupAccountNameW(self, _sys, _name, sid, sid_size, _dom, dom_size, _sid_use):
+                self.calls += 1
+                if self.calls == 1:
+                    sid_size._obj.value = 4
+                    dom_size._obj.value = 4
+                    return False
+                sid.raw = b"ABCD"
+                return True
+
+        monkeypatch.setattr(script.ctypes, "WinDLL", lambda *_args, **_kwargs: _Advapi32(), raising=False)
+
+        assert script._get_user_sid("john", ".") == b"ABCD"
+
+    def test_grant_winsta_desktop_with_missing_sid(self, monkeypatch):
+        monkeypatch.setattr(script, "_get_user_sid", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(script.ctypes, "get_last_error", lambda: 123, raising=False)
+
+        diag = script._grant_winsta_desktop("john", None)
+
+        assert diag == ["_get_user_sid failed: winerror=123"]
+
+    def test_get_current_desktop_str_returns_none_without_winsta(self, monkeypatch):
+        class _User32:
+            def GetProcessWindowStation(self):
+                return 0
+
+        class _Kernel32:
+            def GetCurrentThreadId(self):
+                return 1
+
+        def _fake_windll(name, **_kwargs):
+            if name == "user32":
+                return _User32()
+            if name == "kernel32":
+                return _Kernel32()
+            raise AssertionError(name)
+
+        monkeypatch.setattr(script.ctypes, "WinDLL", _fake_windll, raising=False)
+
+        assert script._get_current_desktop_str() is None
+
+    def test_get_current_desktop_str_returns_station_name(self, monkeypatch):
+        class _User32:
+            def GetProcessWindowStation(self):
+                return 1
+
+            def GetUserObjectInformationW(self, handle, _idx, buf, _size, _length):
+                if handle == 1:
+                    buf.value = "WinSta0"
+                elif handle == 0:
+                    buf.value = ""
+                return True
+
+            def GetThreadDesktop(self, _thread_id):
+                return 0
+
+        class _Kernel32:
+            def GetCurrentThreadId(self):
+                return 1
+
+        def _fake_windll(name, **_kwargs):
+            if name == "user32":
+                return _User32()
+            if name == "kernel32":
+                return _Kernel32()
+            raise AssertionError(name)
+
+        monkeypatch.setattr(script.ctypes, "WinDLL", _fake_windll, raising=False)
+
+        assert script._get_current_desktop_str() == "WinSta0"
+
+    def test_add_ace_to_object_returns_on_get_security_info_error(self, monkeypatch):
+        class _Advapi32:
+            def GetSecurityInfo(self, *_args):
+                return 1
+
+        class _Kernel32:
+            def LocalFree(self, *_args):
+                return 0
+
+        def _fake_windll(name, **_kwargs):
+            if name == "advapi32":
+                return _Advapi32()
+            if name == "kernel32":
+                return _Kernel32()
+            raise AssertionError(name)
+
+        monkeypatch.setattr(script.ctypes, "WinDLL", _fake_windll, raising=False)
+
+        script._add_ace_to_object(
+            handle=1, se_object_type=script.SE_KERNEL_OBJECT, sid=b"SID", access_mask=1, ace_flags=0
+        )
+
+    def test_grant_winsta_desktop_success(self, monkeypatch):
+        monkeypatch.setattr(script, "_get_user_sid", lambda *_args, **_kwargs: b"SID")
+        add_ace_calls = []
+        monkeypatch.setattr(
+            script,
+            "_add_ace_to_object",
+            lambda *args, **kwargs: add_ace_calls.append((args, kwargs)),
+        )
+
+        class _User32:
+            def GetProcessWindowStation(self):
+                return 11
+
+            def GetUserObjectInformationW(self, handle, _idx, buf, _size, _length):
+                if handle == 11:
+                    buf.value = "WinSta0"
+                else:
+                    buf.value = "Default"
+                return True
+
+            def GetThreadDesktop(self, _thread_id):
+                return 22
+
+        class _Kernel32:
+            def GetCurrentThreadId(self):
+                return 7
+
+        def _fake_windll(name, **_kwargs):
+            if name == "user32":
+                return _User32()
+            if name == "kernel32":
+                return _Kernel32()
+            raise AssertionError(name)
+
+        monkeypatch.setattr(script.ctypes, "WinDLL", _fake_windll, raising=False)
+
+        diag = script._grant_winsta_desktop("john", None)
+
+        assert "got SID, len=3" in diag
+        assert "current WinSta: 'WinSta0'" in diag
+        assert "current Desktop: 'Default'" in diag
+        assert "WinSta ACEs added" in diag
+        assert "Desktop ACE added" in diag
+        assert len(add_ace_calls) == 3
+
+    def test_setup_winapi_configures_prototypes(self, monkeypatch):
+        kernel32 = _FakeKernel32()
+        advapi32 = _FakeAdvapi32()
+
+        def _fake_windll(name, use_last_error=True):
+            if name == "kernel32":
+                return kernel32
+            if name == "advapi32":
+                return advapi32
+            raise AssertionError(f"unexpected dll: {name}")
+
+        monkeypatch.setattr(script.ctypes, "WinDLL", _fake_windll, raising=False)
+
+        out_kernel32, out_advapi32 = script._setup_winapi()
+
+        assert out_kernel32 is kernel32
+        assert out_advapi32 is advapi32
+        assert advapi32.CreateProcessWithLogonW.argtypes is not None
+        assert kernel32.WaitForSingleObject.argtypes is not None
+
+    def test_main_requires_single_payload_argument(self, monkeypatch, capsys):
+        monkeypatch.setattr(script.sys, "argv", ["runas_winapi_script.py"])
+        monkeypatch.setattr(script.sys.stdin, "read", lambda: "")
+
+        rc = script.main()
+
+        out = json.loads(capsys.readouterr().out.strip())
+        assert rc == 2
+        assert out["ok"] is False
+
+    def test_main_with_invalid_payload(self, monkeypatch, capsys):
+        monkeypatch.setattr(script.sys, "argv", ["runas_winapi_script.py"])
+        monkeypatch.setattr(script.sys.stdin, "read", lambda: "not-base64")
+
+        rc = script.main()
+
+        out = json.loads(capsys.readouterr().out.strip())
+        assert rc == 2
+        assert out["ok"] is False
+        assert "Failed to decode payload" in out["error"]
+
+    def test_main_create_process_failure(self, monkeypatch, capsys):
+        payload = {
+            "user": "john",
+            "password": "secret",
+            "domain": ".",
+            "cwd": "C:/Temp",
+            "timeout": 5,
+            "runner_bat_path": "C:/Temp/run.bat",
+        }
+        monkeypatch.setattr(script.sys, "argv", ["runas_winapi_script.py"])
+        monkeypatch.setattr(script.sys.stdin, "read", lambda: _encode_payload(payload))
+
+        kernel32 = _FakeKernel32(wait_result=0, exit_code=0)
+        advapi32 = _FakeAdvapi32(created=False)
+        monkeypatch.setattr(script, "_setup_winapi", lambda: (kernel32, advapi32))
+        monkeypatch.setattr(script, "_grant_winsta_desktop", lambda *_args, **_kwargs: [])
+        monkeypatch.setattr(script, "_get_current_desktop_str", lambda: None)
+        monkeypatch.setattr(script, "_last_error_payload", lambda _prefix: {"ok": False, "error": "failure"})
+
+        rc = script.main()
+
+        out = json.loads(capsys.readouterr().out.strip())
+        assert rc == 0
+        assert out["ok"] is False
+        assert out["error"] == "failure"
+
+    def test_main_timeout(self, monkeypatch, capsys):
+        payload = {
+            "user": "john",
+            "password": "secret",
+            "domain": None,
+            "cwd": "C:/Temp",
+            "timeout": 5,
+            "runner_bat_path": "C:/Temp/run.bat",
+        }
+        monkeypatch.setattr(script.sys, "argv", ["runas_winapi_script.py"])
+        monkeypatch.setattr(script.sys.stdin, "read", lambda: _encode_payload(payload))
+
+        kernel32 = _FakeKernel32(wait_result=script.WAIT_TIMEOUT, exit_code=0)
+        advapi32 = _FakeAdvapi32(created=True)
+        monkeypatch.setattr(script, "_setup_winapi", lambda: (kernel32, advapi32))
+        monkeypatch.setattr(script, "_grant_winsta_desktop", lambda *_args, **_kwargs: [])
+        monkeypatch.setattr(script, "_get_current_desktop_str", lambda: None)
+
+        rc = script.main()
+
+        out = json.loads(capsys.readouterr().out.strip())
+        assert rc == 0
+        assert out == {"ok": False, "timeout": True, "returncode": 124}
+
+    def test_main_success(self, monkeypatch, capsys):
+        payload = {
+            "user": "john",
+            "password": "secret",
+            "domain": None,
+            "cwd": "C:/Temp",
+            "timeout": None,
+            "runner_bat_path": "C:/Temp/run.bat",
+        }
+        monkeypatch.setattr(script.sys, "argv", ["runas_winapi_script.py"])
+        monkeypatch.setattr(script.sys.stdin, "read", lambda: _encode_payload(payload))
+
+        kernel32 = _FakeKernel32(wait_result=0, exit_code=7)
+        advapi32 = _FakeAdvapi32(created=True)
+        monkeypatch.setattr(script, "_setup_winapi", lambda: (kernel32, advapi32))
+        monkeypatch.setattr(script, "_grant_winsta_desktop", lambda *_args, **_kwargs: [])
+        monkeypatch.setattr(script, "_get_current_desktop_str", lambda: "WinSta0\\Default")
+
+        rc = script.main()
+
+        out = json.loads(capsys.readouterr().out.strip())
+        assert rc == 0
+        assert out == {"ok": True, "returncode": 7}
+
+    def test_main_payload_from_argv_fallback(self, monkeypatch, capsys):
+        payload = {
+            "user": "john",
+            "password": "secret",
+            "domain": None,
+            "cwd": "C:/Temp",
+            "timeout": None,
+            "runner_bat_path": "C:/Temp/run.bat",
+        }
+        monkeypatch.setattr(script.sys, "argv", ["runas_winapi_script.py", _encode_payload(payload)])
+        monkeypatch.setattr(script.sys.stdin, "read", lambda: "")
+
+        kernel32 = _FakeKernel32(wait_result=0, exit_code=0)
+        advapi32 = _FakeAdvapi32(created=True)
+        monkeypatch.setattr(script, "_setup_winapi", lambda: (kernel32, advapi32))
+        monkeypatch.setattr(script, "_grant_winsta_desktop", lambda *_args, **_kwargs: [])
+        monkeypatch.setattr(script, "_get_current_desktop_str", lambda: None)
+
+        rc = script.main()
+
+        out = json.loads(capsys.readouterr().out.strip())
+        assert rc == 0
+        assert out == {"ok": True, "returncode": 0}


### PR DESCRIPTION
This pull request adds comprehensive support for running commands as another user and managing local users on Windows targets via the `RPyCConnection` class. It introduces new methods for user lifecycle operations, ensures robust handling and cleanup of temporary resources, and improves documentation and error handling for these features.

**Windows run-as-user and user management features:**

* Added `execute_command_as_user`, `create_user`, and `delete_user` methods to `RPyCConnection` for running commands as another user and managing local users on Windows. These methods include detailed error handling and dispatch to platform-specific implementations.
* Implemented a helper method (`_ensure_remote_winapi_helper`) to upload and manage a WinAPI-based script on the remote host for secure run-as-user execution.
* Introduced a new exception, `RunAsUserError`, for handling invalid run-as-user execution scenarios.

**Documentation updates:**

* Updated the `README.md` to document the new Windows run-as-user and user management features, including usage examples and notes on platform support. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R749-R785)

**Internal improvements and refactoring:**

* Improved docstrings for several internal methods, clarifying their purpose and error handling. [[1]](diffhunk://#diff-af6e41f5eef7ef24b24ce6384333df253ada1177689eccb447e447568e31dc1fR187-R193) [[2]](diffhunk://#diff-af6e41f5eef7ef24b24ce6384333df253ada1177689eccb447e447568e31dc1fR1258-R1263) [[3]](diffhunk://#diff-af6e41f5eef7ef24b24ce6384333df253ada1177689eccb447e447568e31dc1fR1277-R1281)
* Added necessary imports and internal utility function usage for user management. [[1]](diffhunk://#diff-af6e41f5eef7ef24b24ce6384333df253ada1177689eccb447e447568e31dc1fR6-R7) [[2]](diffhunk://#diff-af6e41f5eef7ef24b24ce6384333df253ada1177689eccb447e447568e31dc1fR31-R35)