### PR TITLE
feat: Add ipv6 option for rpyc server

### DIFF
--- a/mfd_connect/rpyc.py
+++ b/mfd_connect/rpyc.py
@@ -69,6 +69,7 @@ class RPyCConnection(PythonConnection):
         cache_system_data: bool = True,
         ssl_keyfile: str | None = None,
         ssl_certfile: str | None = None,
+        ipv6: bool = False,
         **kwargs,
     ) -> None:  # noqa: D200
         """
@@ -93,6 +94,7 @@ class RPyCConnection(PythonConnection):
         :param cache_system_data: Flag to cache system data like self._os_type, OS name, OS bitness and CPU architecture
         :param ssl_keyfile: Path to SSL key file.
         :param ssl_certfile: Path to SSL certificate file.
+        :param ipv6: set to ``True`` when *ip* is an IPv6 address (default: ``False``)
         """
         super().__init__(ip, model, default_timeout, cache_system_data)
         self.path_extension = path_extension
@@ -109,6 +111,7 @@ class RPyCConnection(PythonConnection):
         self.share_password: str = share_password
         self._ssl_keyfile: str | None = ssl_keyfile
         self._ssl_certfile: str | None = ssl_certfile
+        self._ipv6: bool = ipv6
         self._establish_connection(retry_timeout=retry_timeout, retry_time=retry_time)
 
     def _establish_connection(self, *, retry_timeout: Optional[int], retry_time: int) -> None:
@@ -250,6 +253,7 @@ class RPyCConnection(PythonConnection):
             return rpyc.ssl_connect(
                 str(self._ip),
                 port=self._port,
+                ipv6=self._ipv6,
                 service=ClassicService,
                 keepalive=True,
                 config={"sync_request_timeout": self._connection_timeout},
@@ -259,6 +263,7 @@ class RPyCConnection(PythonConnection):
         return rpyc.connect(
             str(self._ip),
             port=self._port,
+            ipv6=self._ipv6,
             service=ClassicService,
             keepalive=True,
             config={"sync_request_timeout": self._connection_timeout},

--- a/mfd_connect/rpyc_server/rpyc_server.py
+++ b/mfd_connect/rpyc_server/rpyc_server.py
@@ -34,6 +34,7 @@ def run() -> None:
         help="Port to bind to",
     )
     parser.add_argument("-l", "--log", type=str, default=None, help="Path to log file")
+    parser.add_argument("--ipv6", action="store_true", default=False, help="Listen on IPv6 (binds to '::')")
     parser.add_argument(
         "--ssl-keyfile",
         type=str,

--- a/mfd_connect/rpyc_server/rpyc_server.py
+++ b/mfd_connect/rpyc_server/rpyc_server.py
@@ -56,6 +56,13 @@ def run() -> None:
         from rpyc.utils.authenticators import SSLAuthenticator
 
         authenticator = SSLAuthenticator(keyfile=args.ssl_keyfile, certfile=args.ssl_certfile)
-    server = ThreadedServer(SlaveService, port=args.port, logger=logger, backlog=BACKLOG, authenticator=authenticator)
+    server = ThreadedServer(
+        SlaveService,
+        port=args.port,
+        ipv6=args.ipv6,
+        logger=logger,
+        backlog=BACKLOG,
+        authenticator=authenticator,
+    )
     logger.info("RPyC server initializing")
     server.start()

--- a/mfd_connect/tunneled_rpyc.py
+++ b/mfd_connect/tunneled_rpyc.py
@@ -43,6 +43,7 @@ class TunneledRPyCConnection(RPyCConnection):
         enable_bg_serving_thread: bool = False,
         model: "BaseModel | None" = None,
         cache_system_data: bool = True,
+        ipv6: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -59,6 +60,7 @@ class TunneledRPyCConnection(RPyCConnection):
         :param jump_host_retry_timeout: Time for try of connection, in secs
         :param jump_host_retry_time: Time between next try of connection, in secs
         :param enable_bg_serving_thread: Set to True if background serving thread must be activated, otherwise False
+        :param ipv6: set to ``True`` when *ip* is an IPv6 address (default: ``False``)
         :param model: pydantic model of connection
         :param cache_system_data: Flag to cache system data like self._os_type, OS name, OS bitness and CPU architecture
         """
@@ -83,6 +85,7 @@ class TunneledRPyCConnection(RPyCConnection):
         self._connection = self._tunnel_connection.modules.rpyc.connect(
             str(ip),
             port=port or RPyCConnection.DEFAULT_RPYC_6_0_0_RESPONDER_PORT,
+            ipv6=ipv6,
             service=ClassicService,
             keepalive=True,
             config={"sync_request_timeout": connection_timeout},

--- a/mfd_connect/tunneled_rpyc.py
+++ b/mfd_connect/tunneled_rpyc.py
@@ -44,6 +44,7 @@ class TunneledRPyCConnection(RPyCConnection):
         model: "BaseModel | None" = None,
         cache_system_data: bool = True,
         ipv6: bool = False,
+        jump_host_ipv6: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -60,7 +61,8 @@ class TunneledRPyCConnection(RPyCConnection):
         :param jump_host_retry_timeout: Time for try of connection, in secs
         :param jump_host_retry_time: Time between next try of connection, in secs
         :param enable_bg_serving_thread: Set to True if background serving thread must be activated, otherwise False
-        :param ipv6: set to ``True`` when *ip* is an IPv6 address (default: ``False``)
+        :param ipv6: set to ``True`` when *ip* (target) is an IPv6 address (default: ``False``)
+        :param jump_host_ipv6: set to ``True`` when *jump_host_ip* is an IPv6 address (default: ``False``)
         :param model: pydantic model of connection
         :param cache_system_data: Flag to cache system data like self._os_type, OS name, OS bitness and CPU architecture
         """
@@ -74,6 +76,7 @@ class TunneledRPyCConnection(RPyCConnection):
             enable_bg_serving_thread=enable_bg_serving_thread,
             model=model,
             cache_system_data=cache_system_data,
+            ipv6=jump_host_ipv6,
             **kwargs,
         )
         self._tunnel_connection = self._connection

--- a/tests/unit/test_mfd_connect/test_rpyc.py
+++ b/tests/unit/test_mfd_connect/test_rpyc.py
@@ -37,6 +37,7 @@ class TestRPyCConnection:
             conn._connection_timeout = 360
             conn.path_extension = None
             conn.cache_system_data = True
+            conn._ipv6 = False
             return conn
 
     def test_wait_for_host(self, rpyc, mocker):
@@ -670,6 +671,7 @@ class TestRPyCConnection:
             conn._connection_timeout = 360
             conn.path_extension = None
             conn.cache_system_data = True
+            conn._ipv6 = False
             return conn
 
     def test_execute_with_timeout(self, rpyc_conn_with_timeout, rpyc, mocker):
@@ -807,6 +809,53 @@ class TestRPyCConnection:
         connect_mock.assert_called_once_with(
             str(rpyc._ip),
             port=rpyc._port,
+            service=ClassicService,
+            keepalive=True,
+            config={"sync_request_timeout": rpyc._connection_timeout},
+            keyfile=rpyc._ssl_keyfile,
+            certfile=rpyc._ssl_certfile,
+            ipv6=False,
+        )
+
+    def test__create_connection_with_ipv6(self, rpyc, mocker):
+        # Simulate successful connection with ipv6=True
+        mock_conn = mocker.Mock()
+        rpyc.modules = mocker.Mock()
+        connect_mock = mocker.patch("rpyc.connect", return_value=mock_conn)
+        rpyc._ip = "::1"
+        rpyc._port = 18812
+        rpyc._ssl_keyfile = None
+        rpyc._ssl_certfile = None
+        rpyc._connection_timeout = 10
+        rpyc._ipv6 = True
+        result = RPyCConnection._create_connection(rpyc)
+        assert result == mock_conn
+        connect_mock.assert_called_once_with(
+            str(rpyc._ip),
+            port=rpyc._port,
+            ipv6=True,
+            service=ClassicService,
+            keepalive=True,
+            config={"sync_request_timeout": rpyc._connection_timeout},
+        )
+
+    def test__create_connection_with_ssl_and_ipv6(self, rpyc, mocker):
+        # Simulate successful SSL connection with ipv6=True
+        mock_conn = mocker.Mock()
+        rpyc.modules = mocker.Mock()
+        connect_mock = mocker.patch("rpyc.ssl_connect", return_value=mock_conn)
+        rpyc._ip = "::1"
+        rpyc._port = 18812
+        rpyc._ssl_keyfile = "key.pem"
+        rpyc._ssl_certfile = "cert.pem"
+        rpyc._connection_timeout = 10
+        rpyc._ipv6 = True
+        result = RPyCConnection._create_connection(rpyc)
+        assert result == mock_conn
+        connect_mock.assert_called_once_with(
+            str(rpyc._ip),
+            port=rpyc._port,
+            ipv6=True,
             service=ClassicService,
             keepalive=True,
             config={"sync_request_timeout": rpyc._connection_timeout},

--- a/tests/unit/test_mfd_connect/test_rpyc_server/test_rpyc_server.py
+++ b/tests/unit/test_mfd_connect/test_rpyc_server/test_rpyc_server.py
@@ -11,6 +11,7 @@ from mfd_connect.rpyc_server import rpyc_server
 def test_run_without_log(mock_argparse, mock_threaded_server):
     mock_args = mock_argparse.return_value.parse_args.return_value
     mock_args.log = None
+    mock_args.ipv6 = False
     rpyc_server.run()
     mock_threaded_server.assert_called_once()
 
@@ -20,5 +21,22 @@ def test_run_without_log(mock_argparse, mock_threaded_server):
 def test_run_with_log(mock_argparse, mock_threaded_server):
     mock_args = mock_argparse.return_value.parse_args.return_value
     mock_args.log = "log.txt"
+    mock_args.ipv6 = False
     rpyc_server.run()
     mock_threaded_server.assert_called_once()
+
+
+@patch("mfd_connect.rpyc_server.rpyc_server.ThreadedServer")
+@patch("mfd_connect.rpyc_server.rpyc_server.argparse.ArgumentParser")
+def test_run_with_ipv6(mock_argparse, mock_threaded_server):
+    mock_args = mock_argparse.return_value.parse_args.return_value
+    mock_args.log = None
+    mock_args.ipv6 = True
+    mock_args.port = 18812
+    mock_args.ssl_keyfile = None
+    mock_args.ssl_certfile = None
+    rpyc_server.run()
+    mock_threaded_server.assert_called_once()
+    call_kwargs = mock_threaded_server.call_args[1]
+    assert call_kwargs["ipv6"] is True
+

--- a/tests/unit/test_mfd_connect/test_rpyc_server/test_rpyc_server.py
+++ b/tests/unit/test_mfd_connect/test_rpyc_server/test_rpyc_server.py
@@ -11,7 +11,10 @@ from mfd_connect.rpyc_server import rpyc_server
 def test_run_without_log(mock_argparse, mock_threaded_server):
     mock_args = mock_argparse.return_value.parse_args.return_value
     mock_args.log = None
+    mock_args.port = 18816
     mock_args.ipv6 = False
+    mock_args.ssl_keyfile = None
+    mock_args.ssl_certfile = None
     rpyc_server.run()
     mock_threaded_server.assert_called_once()
 
@@ -21,7 +24,10 @@ def test_run_without_log(mock_argparse, mock_threaded_server):
 def test_run_with_log(mock_argparse, mock_threaded_server):
     mock_args = mock_argparse.return_value.parse_args.return_value
     mock_args.log = "log.txt"
+    mock_args.port = 18816
     mock_args.ipv6 = False
+    mock_args.ssl_keyfile = None
+    mock_args.ssl_certfile = None
     rpyc_server.run()
     mock_threaded_server.assert_called_once()
 

--- a/tests/unit/test_mfd_connect/test_rpyc_server/test_rpyc_server.py
+++ b/tests/unit/test_mfd_connect/test_rpyc_server/test_rpyc_server.py
@@ -45,4 +45,3 @@ def test_run_with_ipv6(mock_argparse, mock_threaded_server):
     mock_threaded_server.assert_called_once()
     call_kwargs = mock_threaded_server.call_args[1]
     assert call_kwargs["ipv6"] is True
-

--- a/tests/unit/test_mfd_connect/test_tunneled_rpyc.py
+++ b/tests/unit/test_mfd_connect/test_tunneled_rpyc.py
@@ -1,0 +1,90 @@
+ # Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: MIT
+"""Tunneled RPyC Connection tests."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from rpyc.core.service import ClassicService
+
+from mfd_connect.tunneled_rpyc import TunneledRPyCConnection
+from mfd_connect.rpyc import RPyCConnection
+
+
+class TestTunneledRPyCConnectionIPv6:
+    """Tests for IPv6 support in TunneledRPyCConnection."""
+
+    @patch.object(RPyCConnection, "__init__", return_value=None)
+    def test_tunneled_rpyc_passes_ipv6_true(self, mock_super_init, mocker):
+        """Test that ipv6=True is passed to rpyc.connect on the tunnel connection."""
+        mock_tunnel_conn = MagicMock()
+        mock_remote_rpyc_connect = mock_tunnel_conn.modules.rpyc.connect
+        mock_remote_rpyc_connect.return_value = MagicMock(closed=False)
+
+        with patch.object(TunneledRPyCConnection, "_set_process_class"):
+            with patch("rpyc.BgServingThread"):
+                with patch.object(TunneledRPyCConnection, "log_tunneled_host_info"):
+                    conn = TunneledRPyCConnection.__new__(TunneledRPyCConnection)
+                    # Set attributes that super().__init__ would set
+                    conn._connection = mock_tunnel_conn
+                    conn._enable_bg_serving_thread = False
+                    conn.path_extension = None
+                    conn._port = None
+                    conn._connection_timeout = 360
+
+                    # Call init logic manually (the part after super().__init__)
+                    conn._tunnel_connection = conn._connection
+                    conn._connection = conn._tunnel_connection.modules.rpyc.connect(
+                        "::1",
+                        port=RPyCConnection.DEFAULT_RPYC_6_0_0_RESPONDER_PORT,
+                        ipv6=True,
+                        service=ClassicService,
+                        keepalive=True,
+                        config={"sync_request_timeout": 360},
+                    )
+
+        mock_remote_rpyc_connect.assert_called_once_with(
+            "::1",
+            port=RPyCConnection.DEFAULT_RPYC_6_0_0_RESPONDER_PORT,
+            ipv6=True,
+            service=ClassicService,
+            keepalive=True,
+            config={"sync_request_timeout": 360},
+        )
+
+    @patch.object(RPyCConnection, "__init__", return_value=None)
+    def test_tunneled_rpyc_passes_ipv6_false_by_default(self, mock_super_init, mocker):
+        """Test that ipv6=False is passed by default."""
+        mock_tunnel_conn = MagicMock()
+        mock_remote_rpyc_connect = mock_tunnel_conn.modules.rpyc.connect
+        mock_remote_rpyc_connect.return_value = MagicMock(closed=False)
+
+        with patch.object(TunneledRPyCConnection, "_set_process_class"):
+            with patch("rpyc.BgServingThread"):
+                with patch.object(TunneledRPyCConnection, "log_tunneled_host_info"):
+                    conn = TunneledRPyCConnection.__new__(TunneledRPyCConnection)
+                    conn._connection = mock_tunnel_conn
+                    conn._enable_bg_serving_thread = False
+                    conn.path_extension = None
+                    conn._port = None
+                    conn._connection_timeout = 360
+
+                    conn._tunnel_connection = conn._connection
+                    conn._connection = conn._tunnel_connection.modules.rpyc.connect(
+                        "10.10.10.10",
+                        port=RPyCConnection.DEFAULT_RPYC_6_0_0_RESPONDER_PORT,
+                        ipv6=False,
+                        service=ClassicService,
+                        keepalive=True,
+                        config={"sync_request_timeout": 360},
+                    )
+
+        mock_remote_rpyc_connect.assert_called_once_with(
+            "10.10.10.10",
+            port=RPyCConnection.DEFAULT_RPYC_6_0_0_RESPONDER_PORT,
+            ipv6=False,
+            service=ClassicService,
+            keepalive=True,
+            config={"sync_request_timeout": 360},
+        )
+

--- a/tests/unit/test_mfd_connect/test_tunneled_rpyc.py
+++ b/tests/unit/test_mfd_connect/test_tunneled_rpyc.py
@@ -17,7 +17,9 @@ class TestTunneledRPyCConnectionIPv6:
     @patch.object(TunneledRPyCConnection, "log_tunneled_host_info")
     @patch.object(TunneledRPyCConnection, "_set_process_class")
     @patch.object(RPyCConnection, "__init__", autospec=True, return_value=None)
-    def test_tunneled_rpyc_passes_ipv6_true(self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg):
+    def test_tunneled_rpyc_passes_ipv6_true(
+        self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg
+    ):
         """Test that ipv6=True is passed to rpyc.connect on the tunnel connection."""
         mock_tunnel_conn = MagicMock()
         mock_remote_rpyc_connect = mock_tunnel_conn.modules.rpyc.connect
@@ -49,7 +51,9 @@ class TestTunneledRPyCConnectionIPv6:
     @patch.object(TunneledRPyCConnection, "log_tunneled_host_info")
     @patch.object(TunneledRPyCConnection, "_set_process_class")
     @patch.object(RPyCConnection, "__init__", autospec=True, return_value=None)
-    def test_tunneled_rpyc_passes_ipv6_false_by_default(self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg):
+    def test_tunneled_rpyc_passes_ipv6_false_by_default(
+        self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg
+    ):
         """Test that ipv6=False is passed by default."""
         mock_tunnel_conn = MagicMock()
         mock_remote_rpyc_connect = mock_tunnel_conn.modules.rpyc.connect
@@ -75,4 +79,3 @@ class TestTunneledRPyCConnectionIPv6:
             keepalive=True,
             config={"sync_request_timeout": 360},
         )
-

--- a/tests/unit/test_mfd_connect/test_tunneled_rpyc.py
+++ b/tests/unit/test_mfd_connect/test_tunneled_rpyc.py
@@ -1,10 +1,9 @@
- # Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: MIT
 """Tunneled RPyC Connection tests."""
 
 from unittest.mock import patch, MagicMock
 
-import pytest
 from rpyc.core.service import ClassicService
 
 from mfd_connect.tunneled_rpyc import TunneledRPyCConnection
@@ -14,34 +13,28 @@ from mfd_connect.rpyc import RPyCConnection
 class TestTunneledRPyCConnectionIPv6:
     """Tests for IPv6 support in TunneledRPyCConnection."""
 
-    @patch.object(RPyCConnection, "__init__", return_value=None)
-    def test_tunneled_rpyc_passes_ipv6_true(self, mock_super_init, mocker):
+    @patch("rpyc.BgServingThread")
+    @patch.object(TunneledRPyCConnection, "log_tunneled_host_info")
+    @patch.object(TunneledRPyCConnection, "_set_process_class")
+    @patch.object(RPyCConnection, "__init__", autospec=True, return_value=None)
+    def test_tunneled_rpyc_passes_ipv6_true(self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg):
         """Test that ipv6=True is passed to rpyc.connect on the tunnel connection."""
         mock_tunnel_conn = MagicMock()
         mock_remote_rpyc_connect = mock_tunnel_conn.modules.rpyc.connect
         mock_remote_rpyc_connect.return_value = MagicMock(closed=False)
 
-        with patch.object(TunneledRPyCConnection, "_set_process_class"):
-            with patch("rpyc.BgServingThread"):
-                with patch.object(TunneledRPyCConnection, "log_tunneled_host_info"):
-                    conn = TunneledRPyCConnection.__new__(TunneledRPyCConnection)
-                    # Set attributes that super().__init__ would set
-                    conn._connection = mock_tunnel_conn
-                    conn._enable_bg_serving_thread = False
-                    conn.path_extension = None
-                    conn._port = None
-                    conn._connection_timeout = 360
+        def fake_super_init(self_inner, *args, **kwargs):
+            self_inner._connection = mock_tunnel_conn
+            self_inner._enable_bg_serving_thread = False
+            self_inner.path_extension = None
 
-                    # Call init logic manually (the part after super().__init__)
-                    conn._tunnel_connection = conn._connection
-                    conn._connection = conn._tunnel_connection.modules.rpyc.connect(
-                        "::1",
-                        port=RPyCConnection.DEFAULT_RPYC_6_0_0_RESPONDER_PORT,
-                        ipv6=True,
-                        service=ClassicService,
-                        keepalive=True,
-                        config={"sync_request_timeout": 360},
-                    )
+        mock_super_init.side_effect = fake_super_init
+
+        TunneledRPyCConnection(
+            ip="::1",
+            jump_host_ip="10.10.10.1",
+            ipv6=True,
+        )
 
         mock_remote_rpyc_connect.assert_called_once_with(
             "::1",
@@ -52,32 +45,27 @@ class TestTunneledRPyCConnectionIPv6:
             config={"sync_request_timeout": 360},
         )
 
-    @patch.object(RPyCConnection, "__init__", return_value=None)
-    def test_tunneled_rpyc_passes_ipv6_false_by_default(self, mock_super_init, mocker):
+    @patch("rpyc.BgServingThread")
+    @patch.object(TunneledRPyCConnection, "log_tunneled_host_info")
+    @patch.object(TunneledRPyCConnection, "_set_process_class")
+    @patch.object(RPyCConnection, "__init__", autospec=True, return_value=None)
+    def test_tunneled_rpyc_passes_ipv6_false_by_default(self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg):
         """Test that ipv6=False is passed by default."""
         mock_tunnel_conn = MagicMock()
         mock_remote_rpyc_connect = mock_tunnel_conn.modules.rpyc.connect
         mock_remote_rpyc_connect.return_value = MagicMock(closed=False)
 
-        with patch.object(TunneledRPyCConnection, "_set_process_class"):
-            with patch("rpyc.BgServingThread"):
-                with patch.object(TunneledRPyCConnection, "log_tunneled_host_info"):
-                    conn = TunneledRPyCConnection.__new__(TunneledRPyCConnection)
-                    conn._connection = mock_tunnel_conn
-                    conn._enable_bg_serving_thread = False
-                    conn.path_extension = None
-                    conn._port = None
-                    conn._connection_timeout = 360
+        def fake_super_init(self_inner, *args, **kwargs):
+            self_inner._connection = mock_tunnel_conn
+            self_inner._enable_bg_serving_thread = False
+            self_inner.path_extension = None
 
-                    conn._tunnel_connection = conn._connection
-                    conn._connection = conn._tunnel_connection.modules.rpyc.connect(
-                        "10.10.10.10",
-                        port=RPyCConnection.DEFAULT_RPYC_6_0_0_RESPONDER_PORT,
-                        ipv6=False,
-                        service=ClassicService,
-                        keepalive=True,
-                        config={"sync_request_timeout": 360},
-                    )
+        mock_super_init.side_effect = fake_super_init
+
+        TunneledRPyCConnection(
+            ip="10.10.10.10",
+            jump_host_ip="10.10.10.1",
+        )
 
         mock_remote_rpyc_connect.assert_called_once_with(
             "10.10.10.10",

--- a/tests/unit/test_mfd_connect/test_tunneled_rpyc.py
+++ b/tests/unit/test_mfd_connect/test_tunneled_rpyc.py
@@ -17,9 +17,7 @@ class TestTunneledRPyCConnectionIPv6:
     @patch.object(TunneledRPyCConnection, "log_tunneled_host_info")
     @patch.object(TunneledRPyCConnection, "_set_process_class")
     @patch.object(RPyCConnection, "__init__", autospec=True, return_value=None)
-    def test_tunneled_rpyc_passes_ipv6_true(
-        self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg
-    ):
+    def test_tunneled_rpyc_passes_ipv6_true(self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg):
         """Test that ipv6=True is passed to rpyc.connect on the tunnel connection."""
         mock_tunnel_conn = MagicMock()
         mock_remote_rpyc_connect = mock_tunnel_conn.modules.rpyc.connect
@@ -51,9 +49,7 @@ class TestTunneledRPyCConnectionIPv6:
     @patch.object(TunneledRPyCConnection, "log_tunneled_host_info")
     @patch.object(TunneledRPyCConnection, "_set_process_class")
     @patch.object(RPyCConnection, "__init__", autospec=True, return_value=None)
-    def test_tunneled_rpyc_passes_ipv6_false_by_default(
-        self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg
-    ):
+    def test_tunneled_rpyc_passes_ipv6_false_by_default(self, mock_super_init, _mock_set_proc, _mock_log, _mock_bg):
         """Test that ipv6=False is passed by default."""
         mock_tunnel_conn = MagicMock()
         mock_remote_rpyc_connect = mock_tunnel_conn.modules.rpyc.connect


### PR DESCRIPTION
fix: add ipv6 option to host rpyc server on ipv6 addresses

Signed-off-by: Wrobel, Tomasz <tomasz.wrobel@intel.com>