### PR TITLE
fix: Adjust shell prompt patterns for PreOS environment handling

### DIFF
--- a/mfd_connect/telnet/telnet.py
+++ b/mfd_connect/telnet/telnet.py
@@ -114,7 +114,12 @@ class TelnetConnection(Connection):
 
     def _get_shell_prompt_patterns(self) -> List[bytes]:
         """Return prompt patterns covering both plain and ANSI-colored shell prompts."""
-        return [self._prompt.encode(), ANSI_SHELL_PROMPT_FALLBACK_REGEX]
+        # In PreOS environment we don't expect ANSI sequences in prompt, so we return only provided prompt pattern.
+        return (
+            [self._prompt.encode(), ANSI_SHELL_PROMPT_FALLBACK_REGEX]
+            if not self._in_pre_os()
+            else [self._prompt.encode()]
+        )
 
     @staticmethod
     def _strip_ansi_sequences(text: str) -> str:


### PR DESCRIPTION
This pull request updates the logic for determining shell prompt patterns in the `Telnet` module to better handle the PreOS environment. The main change ensures that when in PreOS, only the explicit prompt pattern is used, avoiding issues with ANSI escape sequences.

Prompt pattern handling improvements:

* Modified `_get_shell_prompt_patterns` in `telnet.py` to return only the provided prompt pattern (excluding ANSI fallback) when `_in_pre_os()` is `True`, ensuring correct prompt detection in PreOS environments.