### PR TITLE
chore: bump pytest, mfd-code-quality, and paramiko requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements-test.txt  # Ensure tests dependencies are automatically included
 pydantic
-mfd-code-quality >= 1.2.0, < 2
+mfd-code-quality >= 1.4.1, < 2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt  # Ensure tests dependencies are automatically included
 
-pytest ~= 8.4
+pytest >= 9.0.3, < 10
 pytest-mock ~= 3.14
 
 coverage ~= 7.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pexpect~=4.8.0
-paramiko==3.4.0; platform_system != 'VMkernel'
+paramiko==5.0.0; platform_system != 'VMkernel'
 six
 rpyc~=6.0.0
 funcy~=1.14


### PR DESCRIPTION
## Summary
- bump `pytest` in `requirements-test.txt` to `>= 9.0.3, < 10`
- bump `mfd-code-quality` in `requirements-dev.txt` to `>= 1.4.1, < 2`
- bump `paramiko` in `requirements.txt` to `== 5.0.0`
