### PR TITLE
fix: Handle correctly execution reconnect over SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,9 @@ Methods supported:
   The execute_command method in SSHConnection includes a feature that attempts to reconnect to the session in case of failure. If the connection drops during command execution, the method will:
 
   1. Attempt to reconnect to the SSH session.
-  2. Execute a test command (```hostname```) to verify the connection.
-  3. Retry executing the original command, number of retries and timeout can be set in the method with parameters:
-      1. `reconnect_attempts: int = 5` - Number of retries to attempt.
-      2. `attempt_delay: int = 6` - delay in seconds between retries.
+  2. If reconnection succeeds, retry executing the original command once. The number of reconnection attempts and delay between attempts can be set in the method with parameters:
+      1. `reconnect_attempts: int = 5` - Number of reconnection attempts to make.
+      2. `attempt_delay: int = 6` - Delay in seconds between reconnection attempts.
 
   This feature ensures that transient connection issues do not cause command execution to fail permanently.
   

--- a/mfd_connect/ssh.py
+++ b/mfd_connect/ssh.py
@@ -421,83 +421,44 @@ class SSHConnection(AsyncConnection):
                 f"Timeout of {timeout} seconds expired during execution of '{command}' command"
             )
 
-    def handle_execution_reconnect(
-        self,
-        command: str,
-        *,
-        input_data: str | None = None,
-        cwd: str | None = None,
-        timeout: int | None = None,
-        env: dict | None = None,
-        stderr_to_stdout: bool = False,
-        discard_stdout: bool = False,
-        discard_stderr: bool = False,
-        custom_exception: Type[CalledProcessError] | None = None,
-        reconnect_attempts: int = 5,
-        attempt_delay: int = 6,
-    ) -> None:
+    def handle_execution_reconnect(self, reconnect_attempts: int = 5, attempt_delay: int = 6) -> None:
         """
-        Try to reconnect to and make attempts to execute test command.
+        Try to reconnect to host.
 
-        :param command: Command to execute, with all necessary arguments
-        :param input_data: Data to pass to program on the standard input
-        :param cwd: Directory to start program execution in
-        :param timeout: Program execution timeout, in seconds
-        :param env: Environment to execute the program in
-        :param stderr_to_stdout: Redirect stderr to stdout, ignored if discard_stderr is set to True
-        :param discard_stdout: Don't capture stdout stream
-        :param discard_stderr: Don't capture stderr stream
-        :param custom_exception: Enable us to raise our exception if program exits with an unexpected return code.
         :param reconnect_attempts: Number of attempts to reconnect to the host if connection is lost.
         :param attempt_delay: Delay between reconnection attempts.
-        custom_exception must inherit from CalledProcessError to use its fields like returncode, cmd, output, stderr
 
-        :raises TimeoutExpired: if program doesn't conclude before timeout is reached
-        :raises ValueError: if command has invalid characters inside
-        :raises ConnectionCalledProcessError: if program exits with an unexpected return code
+        :return: None
+        :raises ValueError: If reconnect_attempts is not positive or attempt_delay is negative.
+        :raises SSHReconnectException: If reconnection attempts are exhausted without success.
         """
+        if reconnect_attempts <= 0:
+            raise ValueError("reconnect_attempts must be greater than 0")
+        if attempt_delay < 0:
+            raise ValueError("attempt_delay must be greater than or equal to 0")
+
+        last_error = None
+        initial_attempts = reconnect_attempts
         while reconnect_attempts > 0:
             reconnect_success = False
             try:
                 self._reconnect()
                 reconnect_success = True
-            except SSHReconnectException as rec_err:
+            except (SSHException, SSHReconnectException) as rec_err:
                 logger.log(level=log_levels.MODULE_DEBUG, msg=f"Connection drop while trying to reconnect: {rec_err}")
+                if last_error is None:
+                    last_error = rec_err
 
-            if not reconnect_success:
+            if reconnect_success:
+                return
+
+            reconnect_attempts -= 1
+            if reconnect_attempts > 0:
                 time.sleep(attempt_delay)
-                reconnect_attempts -= 1
-                continue
-
-            try:
-                _stdin_pipe, _stdout_pipe, _stderr_pipe, rc = self._exec_command(
-                    "hostname",
-                    input_data=input_data,
-                    environment=env,
-                    cwd=cwd,
-                    timeout=timeout,
-                    stderr_to_stdout=stderr_to_stdout,
-                    discard_stdout=discard_stdout,
-                    discard_stderr=discard_stderr,
-                    get_pty=False,
-                )
-                if rc == 0:
-                    logger.log(level=log_levels.MODULE_DEBUG, msg="Successfully executed test command after reconnect")
-                    return
-            except Exception as e:
-                reconnect_attempts -= 1
-                logger.log(
-                    level=log_levels.MODULE_DEBUG,
-                    msg=f"Connection drop after reconnect when executing test command: {e}",
-                )
         else:
-            logger.log(
-                level=log_levels.MODULE_DEBUG,
-                msg=f"Unable to execute command '{command}' after multiple attempts to reconnect",
-            )
-            if custom_exception:
-                raise custom_exception(returncode=-1, cmd=command, output="", stderr="")
-            raise ConnectionCalledProcessError(returncode=-1, cmd=command, output="", stderr="")
+            raise SSHReconnectException(
+                f"Failed to reconnect to host after {initial_attempts} attempts."
+            ) from last_error
 
     def execute_command(
         self,
@@ -592,19 +553,22 @@ class SSHConnection(AsyncConnection):
             )
 
         if not success_execution:
-            self.handle_execution_reconnect(
-                command,
-                input_data=input_data,
-                cwd=cwd,
-                timeout=timeout,
-                env=env,
-                stderr_to_stdout=stderr_to_stdout,
-                discard_stdout=discard_stdout,
-                discard_stderr=discard_stderr,
-                custom_exception=custom_exception,
-                reconnect_attempts=reconnect_attempts,
-                attempt_delay=attempt_delay,
-            )
+            try:
+                self.handle_execution_reconnect(reconnect_attempts=reconnect_attempts, attempt_delay=attempt_delay)
+            except SSHReconnectException as reconnect_err:
+                if custom_exception:
+                    raise custom_exception(
+                        returncode=-1,
+                        cmd=command,
+                        output="",
+                        stderr=str(reconnect_err),
+                    ) from reconnect_err
+                raise ConnectionCalledProcessError(
+                    returncode=-1,
+                    cmd=command,
+                    output="",
+                    stderr=str(reconnect_err),
+                ) from reconnect_err
 
             logger.log(level=log_levels.CMD, msg=f"Executing >{self._ip}> '{command}' after reconnect, cwd: {cwd}")
             stdin_pipe, stdout_pipe, stderr_pipe, returncode = self._exec_command(

--- a/tests/unit/test_mfd_connect/test_ssh.py
+++ b/tests/unit/test_mfd_connect/test_ssh.py
@@ -362,6 +362,36 @@ class TestSSHConnection:
         )
         assert result.return_code == 0
 
+    def test_execute_command_with_reconnect_fail_raises_connection_called_process_error(self, ssh, mocker):
+        ssh._verify_command_correctness = mocker.Mock()
+        ssh._adjust_command = mocker.Mock(return_value="test_command")
+        ssh._exec_command = mocker.Mock(side_effect=EOFError)
+        ssh.handle_execution_reconnect = mocker.Mock(side_effect=SSHReconnectException("Reconnect exhausted"))
+
+        with pytest.raises(ConnectionCalledProcessError) as exc_info:
+            ssh.execute_command("test_command")
+
+        assert exc_info.value.returncode == -1
+        assert exc_info.value.cmd == "test_command"
+        assert exc_info.value.output == ""
+        assert "Reconnect exhausted" in str(exc_info.value.stderr)
+        assert isinstance(exc_info.value.__cause__, SSHReconnectException)
+
+    def test_execute_command_with_reconnect_fail_raises_custom_exception(self, ssh, mocker):
+        ssh._verify_command_correctness = mocker.Mock()
+        ssh._adjust_command = mocker.Mock(return_value="test_command")
+        ssh._exec_command = mocker.Mock(side_effect=EOFError)
+        ssh.handle_execution_reconnect = mocker.Mock(side_effect=SSHReconnectException("Reconnect exhausted"))
+
+        with pytest.raises(self.CustomTestException) as exc_info:
+            ssh.execute_command("test_command", custom_exception=self.CustomTestException)
+
+        assert exc_info.value.returncode == -1
+        assert exc_info.value.cmd == "test_command"
+        assert exc_info.value.output == ""
+        assert "Reconnect exhausted" in str(exc_info.value.stderr)
+        assert isinstance(exc_info.value.__cause__, SSHReconnectException)
+
     def test_execute_command_skip_logging_provided(self, ssh, mocker, caplog):
         caplog.set_level(0)
         channel = mocker.create_autospec(ChannelFile)
@@ -605,84 +635,65 @@ class TestSSHConnection:
         ssh.send_command_and_disconnect_platform.assert_called_with("sudo shutdown -h now")
 
     def test_handle_execution_reconnect_success(self, ssh, mocker):
-        time.sleep = mocker.Mock(return_value=None)
+        sleep_mock = mocker.patch("mfd_connect.ssh.time.sleep")
         ssh._reconnect = mocker.Mock()
-        ssh._exec_command = mocker.Mock(return_value=(None, None, None, 0))
-        ssh.handle_execution_reconnect("test_command")
+        ssh.handle_execution_reconnect()
         ssh._reconnect.assert_called_once()
-        ssh._exec_command.assert_called_once_with(
-            "hostname",
-            input_data=None,
-            cwd=None,
-            timeout=None,
-            environment=None,
-            stderr_to_stdout=False,
-            discard_stdout=False,
-            discard_stderr=False,
-            get_pty=False,
-        )
+        sleep_mock.assert_not_called()
 
     def test_handle_execution_reconnect_fail_success(self, ssh, mocker):
-        time.sleep = mocker.Mock(return_value=None)
-        ssh._reconnect = mocker.Mock(side_effect=[SSHReconnectException, None])
-        ssh._exec_command = mocker.Mock(return_value=(None, None, None, 0))
-        ssh.handle_execution_reconnect("test_command")
-        ssh._exec_command.assert_called_once_with(
-            "hostname",
-            input_data=None,
-            cwd=None,
-            timeout=None,
-            environment=None,
-            stderr_to_stdout=False,
-            discard_stdout=False,
-            discard_stderr=False,
-            get_pty=False,
-        )
+        sleep_mock = mocker.patch("mfd_connect.ssh.time.sleep")
+        ssh._reconnect = mocker.Mock(side_effect=[SSHReconnectException("Initial reconnect error"), None])
+        ssh.handle_execution_reconnect()
         assert ssh._reconnect.call_count == 2
-        assert ssh._exec_command.call_count == 1
+        sleep_mock.assert_called_once_with(6)
 
-    def test_handle_execution_reconnect_success_test_cmd_fail_success(self, ssh, mocker):
-        time.sleep = mocker.Mock(return_value=None)
+    def test_handle_execution_reconnect_fail_raises_after_all_attempts(self, ssh, mocker):
+        sleep_mock = mocker.patch("mfd_connect.ssh.time.sleep")
+        original_error = SSHReconnectException("Original reconnect error")
         ssh._reconnect = mocker.Mock()
-        ssh._exec_command = mocker.Mock(side_effect=[SSHReconnectException, (None, None, None, 0)])
-        ssh.handle_execution_reconnect("test_command")
-        ssh._exec_command.assert_any_call(
-            "hostname",
-            input_data=None,
-            cwd=None,
-            timeout=None,
-            environment=None,
-            stderr_to_stdout=False,
-            discard_stdout=False,
-            discard_stderr=False,
-            get_pty=False,
-        )
-        assert ssh._reconnect.call_count == 2
-        assert ssh._exec_command.call_count == 2
+        ssh._reconnect.side_effect = [original_error, SSHReconnectException("Second reconnect error")]
 
-    def test_handle_execution_reconnect_success_test_cmd_fail(self, ssh, mocker):
-        time.sleep = mocker.Mock(return_value=None)
+        with pytest.raises(SSHReconnectException) as exc_info:
+            ssh.handle_execution_reconnect(reconnect_attempts=2, attempt_delay=1)
+
+        assert ssh._reconnect.call_count == 2
+        assert sleep_mock.call_count == 1
+        sleep_mock.assert_called_once_with(1)
+        assert "2 attempts" in str(exc_info.value)
+        assert exc_info.value.__cause__ is original_error
+
+    def test_handle_execution_reconnect_catches_ssh_exception(self, ssh, mocker):
+        """Test that SSHException from _reconnect() is caught and retried."""
+        sleep_mock = mocker.patch("mfd_connect.ssh.time.sleep")
+        original_error = paramiko.SSHException("SSH connection failed")
         ssh._reconnect = mocker.Mock()
-        ssh._exec_command = mocker.Mock(
-            side_effect=[SSHReconnectException, SSHReconnectException, SSHReconnectException, SSHReconnectException]
-        )
+        ssh._reconnect.side_effect = [original_error, SSHReconnectException("Still failed")]
 
-        with pytest.raises(ConnectionCalledProcessError):
-            ssh.handle_execution_reconnect("test_command", reconnect_attempts=2)
+        with pytest.raises(SSHReconnectException) as exc_info:
+            ssh.handle_execution_reconnect(reconnect_attempts=2, attempt_delay=1)
 
-        ssh._exec_command.assert_any_call(
-            "hostname",
-            input_data=None,
-            cwd=None,
-            timeout=None,
-            environment=None,
-            stderr_to_stdout=False,
-            discard_stdout=False,
-            discard_stderr=False,
-            get_pty=False,
-        )
         assert ssh._reconnect.call_count == 2
-        assert ssh._exec_command.call_count == 2
+        assert sleep_mock.call_count == 1
+        assert "2 attempts" in str(exc_info.value)
+        assert exc_info.value.__cause__ is original_error
+
+    @pytest.mark.parametrize("reconnect_attempts", [0, -1])
+    def test_handle_execution_reconnect_invalid_reconnect_attempts(self, ssh, reconnect_attempts):
+        ssh._reconnect = Mock()
+
+        with pytest.raises(ValueError, match="reconnect_attempts must be greater than 0"):
+            ssh.handle_execution_reconnect(reconnect_attempts=reconnect_attempts)
+
+        ssh._reconnect.assert_not_called()
+
+    def test_handle_execution_reconnect_invalid_attempt_delay(self, ssh):
+        ssh._reconnect = Mock()
+
+        with pytest.raises(ValueError, match="attempt_delay must be greater than or equal to 0"):
+            ssh.handle_execution_reconnect(reconnect_attempts=1, attempt_delay=-1)
+
+        ssh._reconnect.assert_not_called()
 
     def test_download_file_from_url_windows_ssh_no_supported(self, ssh, mocker):
         ssh.get_os_name = mocker.Mock(return_value=OSName.WINDOWS)


### PR DESCRIPTION
This pull request updates the reconnection logic for executing a specified command by removing the execution of the ‘hostname’ test command, since mfd-connect executes the ‘uname -a’ command during connection initialization, and if that command succeeds, it should be sufficient to consider the connection renewal successful.