### PR TITLE
fix: increase timeout for EFI shell check command to improve reliability

### DIFF
--- a/mfd_connect/rshell.py
+++ b/mfd_connect/rshell.py
@@ -246,7 +246,7 @@ class RShellConnection(Connection):
         """Check if EFI shell is the client OS."""
         efi_shell_check_command = "ver"
         output = self.execute_command(
-            efi_shell_check_command, shell=False, expected_return_codes=None, timeout=5
+            efi_shell_check_command, shell=False, expected_return_codes=None, timeout=10
         ).stdout
         return any(out in output for out in ["UEFI Shell", "UEFI Interactive Shell"])
 


### PR DESCRIPTION
This pull request makes a minor update to the EFI shell detection logic by increasing the command execution timeout from 5 to 10 seconds in the `_check_if_efi_shell` method. This change helps improve reliability in environments where command responses may be slower.