### PR TITLE
feat: Add support for copying via SSH using key_path instead of password

### DIFF
--- a/mfd_connect/ssh.py
+++ b/mfd_connect/ssh.py
@@ -68,7 +68,7 @@ class SSHConnection(AsyncConnection):
         *args,
         port: int = 22,
         username: str,
-        password: Optional[str],
+        password: str | None = None,
         key_path: "list[str | Path] | str | Path | None" = None,
         skip_key_verification: bool = False,
         model: "BaseModel | None" = None,

--- a/mfd_connect/util/rpc_copy_utils.py
+++ b/mfd_connect/util/rpc_copy_utils.py
@@ -28,7 +28,7 @@ import logging
 import time
 from functools import partial
 from ipaddress import IPv4Address
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING, Union, Optional
 
 from mfd_common_libs import log_levels, DisableLogger
@@ -865,6 +865,26 @@ def _ssh_copy_locally(
     :param src_conn: Source connection object
     :param target: Path to where file should be copied.
     """
+
+    def _normalize_scp_path(path: Path) -> str:
+        path_str = str(path)
+        # PureWindowsPath gives stable slash normalization across Linux/Windows runners.
+        if "\\" in path_str or ":" in path_str:
+            return PureWindowsPath(path_str).as_posix()
+        return path_str
+
+    def _scp_key_args(conn: "SSHConnection | TunneledSSHConnection") -> str:
+        key_filename = conn._connection_details.get("key_filename")
+        if isinstance(key_filename, list):
+            key_filename = key_filename[0] if key_filename else None
+        if key_filename is None:
+            return ""
+        return rf' -i "{key_filename}"'
+
+    SCP_ARGS = " -o BatchMode=yes -o StrictHostKeyChecking=no -r"
+    source_scp = _normalize_scp_path(source)
+    target_scp = _normalize_scp_path(target)
+
     if src_conn._os_type == OSType.POSIX and isinstance(dst_conn, dst_connections):
         user = dst_conn._connection_details.get("username")
         password = dst_conn._connection_details.get("password")
@@ -872,8 +892,14 @@ def _ssh_copy_locally(
         shell = False if src_conn.get_os_name() == OSName.FREEBSD else True
         add_known_host(ip=dst_conn.ip, port=22, connection=src_conn, shell=shell)
 
-        target = target.as_posix() if dst_conn._os_type == OSType.WINDOWS else target
-        command = rf'sshpass -p "{password}" scp -o StrictHostKeyChecking=no -r {source} {user}@{dst_conn.ip}:{target}'
+        if password is None:
+            key_args = _scp_key_args(dst_conn)
+            command = rf"scp{key_args}{SCP_ARGS} {source_scp} {user}@{dst_conn.ip}:{target_scp}"
+        else:
+            command = (
+                rf'sshpass -p "{password}" scp -o StrictHostKeyChecking=no -r {source_scp} '
+                rf"{user}@{dst_conn.ip}:{target_scp}"
+            )
         src_conn.execute_command(command=command, cwd="/", shell=shell)
 
         _remove_ip_from_known_host(src_conn, dst_conn.ip)
@@ -884,8 +910,14 @@ def _ssh_copy_locally(
         shell = False if src_conn.get_os_name() == OSName.FREEBSD else True
         add_known_host(ip=src_conn.ip, port=22, connection=dst_conn, shell=shell)
 
-        source = source.as_posix() if dst_conn._os_type != OSType.WINDOWS else source
-        command = rf'sshpass -p "{password}" scp -o StrictHostKeyChecking=no -r {user}@{src_conn.ip}:{source} {target}'
+        if password is None:
+            key_args = _scp_key_args(src_conn)
+            command = rf"scp{key_args}{SCP_ARGS} {user}@{src_conn.ip}:{source_scp} {target_scp}"
+        else:
+            command = (
+                rf'sshpass -p "{password}" scp -o StrictHostKeyChecking=no -r '
+                rf"{user}@{src_conn.ip}:{source_scp} {target_scp}"
+            )
         dst_conn.execute_command(command=command, cwd="/", shell=shell)
 
         _remove_ip_from_known_host(dst_conn, src_conn.ip)
@@ -893,15 +925,24 @@ def _ssh_copy_locally(
     elif src_conn._os_type == OSType.WINDOWS and isinstance(dst_conn, dst_connections):
         user = dst_conn._connection_details.get("username")
         password = dst_conn._connection_details.get("password")
-        source = source.as_posix() if src_conn._os_type == OSType.WINDOWS else source
-        command = rf"echo y | pscp -r -scp -pw {password} {source} {user}@{dst_conn.ip}:{target}"
+
+        if password is None:
+            key_args = _scp_key_args(dst_conn)
+            command = rf"scp{key_args}{SCP_ARGS} {source_scp} {user}@{dst_conn.ip}:{target_scp}"
+        else:
+            source_pscp = source.as_posix() if src_conn._os_type == OSType.WINDOWS else source
+            command = rf"echo y | pscp -r -scp -pw {password} {source_pscp} {user}@{dst_conn.ip}:{target}"
         src_conn.execute_command(command=command, shell=True)
 
     elif dst_conn._os_type == OSType.WINDOWS and isinstance(src_conn, dst_connections):
         user = src_conn._connection_details.get("username")
         password = src_conn._connection_details.get("password")
-        target = target.as_posix() if dst_conn._os_type == OSType.WINDOWS else target
-        command = rf"echo y | pscp -r -scp -pw {password} {user}@{src_conn.ip}:{source} {target}"
+        if password is None:
+            key_args = _scp_key_args(src_conn)
+            command = rf"scp{key_args}{SCP_ARGS} {user}@{src_conn.ip}:{source_scp} {target_scp}"
+        else:
+            target_pscp = target.as_posix() if dst_conn._os_type == OSType.WINDOWS else target
+            command = rf"echo y | pscp -r -scp -pw {password} {user}@{src_conn.ip}:{source} {target_pscp}"
         dst_conn.execute_command(command=command, shell=True)
 
 

--- a/tests/unit/test_mfd_connect/test_utils/test_rpc_copy_utils.py
+++ b/tests/unit/test_mfd_connect/test_utils/test_rpc_copy_utils.py
@@ -413,6 +413,147 @@ class TestRPCCopyUtils:
         ]
         src_conn.execute_command.assert_has_calls(calls)
 
+    def test_copy_remote_ssh_posix_without_password(self, mocker):
+        src_conn = dst_conn = mocker.create_autospec(SSHConnection)
+        src_conn._os_type = dst_conn._os_type = OSType.POSIX
+        dst_conn._connection_details = {"username": "user", "password": None}
+        dst_conn._ip = "10.10.10.20"
+        dst_conn.ip = dst_conn._ip
+        source = "/root/test"
+        target = "/root/copied_test"
+
+        _copy_remote_ssh(src_conn=src_conn, dst_conn=dst_conn, source=source, target=target)
+        src_conn._os_type = dst_conn._os_type = OSType.POSIX
+        src_conn.get_os_type.return_value = OSType.POSIX
+        dst_conn._connection_details = {"username": "user", "password": None}
+        dst_conn._ip = "10.10.10.20"
+        dst_conn.ip = dst_conn._ip
+        source = "/root/test"
+        target = "/root/copied_test"
+
+        _copy_remote_ssh(src_conn=src_conn, dst_conn=dst_conn, source=source, target=target)
+
+        calls = [
+            call(command="ping -n 1 10.10.10.20", shell=True),
+            call(r"ssh-keyscan -p 22 10.10.10.20 >> ~/.ssh/known_hosts", cwd="/", shell=True),
+            call(
+                r"scp -o BatchMode=yes -o StrictHostKeyChecking=no -r /root/test user@10.10.10.20:/root/copied_test",
+                cwd="/",
+                shell=True,
+            ),
+            call("sed -i '/10.10.10.20/d' ~/.ssh/known_hosts", shell=True),
+        ]
+        src_conn.execute_command.assert_has_calls(calls)
+
+    def test_copy_remote_ssh_posix_dst_local_without_password(self, mocker):
+        src_conn = mocker.create_autospec(SSHConnection)
+        dst_conn = mocker.create_autospec(LocalConnection)
+        mocker.patch("mfd_connect.util.rpc_copy_utils._check_if_ip_is_reachable", return_value=True)
+        src_conn._os_type = OSType.POSIX
+        dst_conn._os_type = OSType.POSIX
+        src_conn._connection_details = {"username": "user", "password": None}
+        src_conn._ip = "10.10.10.20"
+        src_conn.ip = src_conn._ip
+        source = PurePath("/root/test_dir")
+        target = PurePath("/tmp/copied_test_dir")
+
+        _copy_remote_ssh(src_conn=src_conn, dst_conn=dst_conn, source=source, target=target)
+
+        dst_conn.execute_command.assert_has_calls(
+            [
+                call(command=r"ssh-keyscan -p 22 10.10.10.20 >> ~/.ssh/known_hosts", cwd="/", shell=True),
+                call(
+                    command=r"scp -o BatchMode=yes -o StrictHostKeyChecking=no -r user@10.10.10.20:/root/test_dir"
+                    r" /tmp/copied_test_dir",
+                    cwd="/",
+                    shell=True,
+                ),
+                call("sed -i '/10.10.10.20/d' ~/.ssh/known_hosts", shell=True),
+            ]
+        )
+
+    def test_copy_remote_ssh_posix_dst_local_with_password(self, mocker):
+        src_conn = mocker.create_autospec(SSHConnection)
+        dst_conn = mocker.create_autospec(LocalConnection)
+        mocker.patch("mfd_connect.util.rpc_copy_utils._check_if_ip_is_reachable", return_value=True)
+        src_conn._os_type = OSType.POSIX
+        src_conn.get_os_name.return_value = OSName.LINUX
+        dst_conn._os_type = OSType.POSIX
+        src_conn._connection_details = {"username": "user", "password": "pass"}
+        src_conn._ip = "10.10.10.20"
+        src_conn.ip = src_conn._ip
+        source = PurePath("/root/test_dir")
+        target = PurePath("/tmp/copied_test_dir")
+
+        _copy_remote_ssh(src_conn=src_conn, dst_conn=dst_conn, source=source, target=target)
+
+        dst_conn.execute_command.assert_has_calls(
+            [
+                call(command=r"ssh-keyscan -p 22 10.10.10.20 >> ~/.ssh/known_hosts", cwd="/", shell=True),
+                call(
+                    command=r'sshpass -p "pass" scp -o StrictHostKeyChecking=no -r user@10.10.10.20:/root/test_dir '
+                    r"/tmp/copied_test_dir",
+                    cwd="/",
+                    shell=True,
+                ),
+                call("sed -i '/10.10.10.20/d' ~/.ssh/known_hosts", shell=True),
+            ]
+        )
+
+    def test_copy_remote_ssh_windows_src_to_posix_with_key_without_password(self, mocker):
+        src_conn = mocker.create_autospec(LocalConnection)
+        dst_conn = mocker.create_autospec(SSHConnection)
+        mocker.patch("mfd_connect.util.rpc_copy_utils._check_if_ip_is_reachable", return_value=True)
+        src_conn._os_type = OSType.WINDOWS
+        dst_conn._os_type = OSType.POSIX
+        dst_conn._connection_details = {
+            "username": "user",
+            "password": None,
+            "key_filename": r"C:\\Users\\agorczew\\.ssh\\id_rsa",
+        }
+        dst_conn._ip = "10.10.10.20"
+        dst_conn.ip = dst_conn._ip
+        source = PurePath(r"C:\test_dir")
+        target = PurePath("/root/copied_test_dir")
+
+        _copy_remote_ssh(src_conn=src_conn, dst_conn=dst_conn, source=source, target=target)
+
+        src_conn.execute_command.assert_called_once()
+        assert src_conn.execute_command.call_args.kwargs["shell"] is True
+        command = src_conn.execute_command.call_args.kwargs["command"]
+        assert r'scp -i "C:\\Users\\agorczew\\.ssh\\id_rsa"' in command
+        assert "-o BatchMode=yes" in command
+        assert "-o StrictHostKeyChecking=no" in command
+        assert "C:/test_dir" in command
+        assert r"user@10.10.10.20:/root/copied_test_dir" in command
+
+    def test_copy_remote_ssh_windows_src_to_posix_with_key_list_without_password(self, mocker):
+        src_conn = mocker.create_autospec(LocalConnection)
+        dst_conn = mocker.create_autospec(SSHConnection)
+        mocker.patch("mfd_connect.util.rpc_copy_utils._check_if_ip_is_reachable", return_value=True)
+        src_conn._os_type = OSType.WINDOWS
+        dst_conn._os_type = OSType.POSIX
+        dst_conn._connection_details = {
+            "username": "user",
+            "password": None,
+            "key_filename": [r"C:\\Users\\agorczew\\.ssh\\id_ed25519", r"C:\\Users\\agorczew\\.ssh\\id_rsa"],
+        }
+        dst_conn._ip = "10.10.10.20"
+        dst_conn.ip = dst_conn._ip
+        source = PurePath(r"C:\test_dir")
+        target = PurePath("/root/copied_test_dir")
+
+        _copy_remote_ssh(src_conn=src_conn, dst_conn=dst_conn, source=source, target=target)
+
+        src_conn.execute_command.assert_called_once()
+        assert src_conn.execute_command.call_args.kwargs["shell"] is True
+        command = src_conn.execute_command.call_args.kwargs["command"]
+        assert r'scp -i "C:\\Users\\agorczew\\.ssh\\id_ed25519"' in command
+        assert "-o BatchMode=yes" in command
+        assert "-o StrictHostKeyChecking=no" in command
+        assert "C:/test_dir" in command
+        assert r"user@10.10.10.20:/root/copied_test_dir" in command
+
     def test_source_not_exist(self, mocker):
         ssh_conn = mocker.create_autospec(SSHConnection)
         source = Path(r"C:\test_dir")


### PR DESCRIPTION
This pull request enhances SSH-based file copy operations by adding support for key-based authentication (when no password is provided) and improves test coverage for these scenarios. It also makes minor adjustments to logging and type annotations.

**Key-based authentication and command generation improvements:**

* Added logic in `_ssh_copy_locally` (in `mfd_connect/util/rpc_copy_utils.py`) to detect when password is `None` and use key-based `scp` commands, including handling `key_filename` if provided. This avoids using `sshpass` and sets appropriate SSH options for key-based auth. [[1]](diffhunk://#diff-847561d06386a1be2f8bfdc4f75fc336cb4cff14404ca20e40b728cb54066d9dR868-R876) [[2]](diffhunk://#diff-847561d06386a1be2f8bfdc4f75fc336cb4cff14404ca20e40b728cb54066d9dL876-R891) [[3]](diffhunk://#diff-847561d06386a1be2f8bfdc4f75fc336cb4cff14404ca20e40b728cb54066d9dL888-R909) [[4]](diffhunk://#diff-847561d06386a1be2f8bfdc4f75fc336cb4cff14404ca20e40b728cb54066d9dR918-R932)
* Introduced the helper function `_scp_key_args` to correctly format the `-i` argument for `scp` when a key file is specified.

**Testing improvements:**

* Added new unit tests in `tests/unit/test_mfd_connect/test_utils/test_rpc_copy_utils.py` to verify that key-based authentication works correctly for various OS and connection combinations, and that the correct `scp` commands are generated.

**Other changes:**

* Updated the type annotation for the `password` parameter in the SSH connection `__init__` to use `str | None = None` for better clarity and default handling.
* Changed logging configuration for the `paramiko` library from `WARNING` to `MODULE_DEBUG` level.