### PR TITLE
feat: Hide outputs in the logs for path.exists method

### DIFF
--- a/mfd_connect/pathlib/path.py
+++ b/mfd_connect/pathlib/path.py
@@ -9,7 +9,7 @@ import typing
 from pathlib import PurePath, PurePosixPath, PureWindowsPath
 from typing import Union, Optional, Sequence
 
-from mfd_common_libs import add_logging_level, log_levels
+from mfd_common_libs import DisableLogger, add_logging_level, log_levels
 from mfd_typing.os_values import OSType, OSName
 
 from mfd_connect.exceptions import NotAFileError, ModuleFrameworkDesignError
@@ -347,11 +347,17 @@ class CustomPosixPath(CustomPath, PurePosixPath):
     """Class for Posix Path."""
 
     def exists(self) -> bool:  # noqa:D102
-        outcome = self._owner.execute_command(f"ls {self}", expected_return_codes=None)
-        output = outcome.stderr if outcome._stderr is not None else outcome.stdout
-        if "permission denied".casefold() in output.casefold():
-            raise ModuleFrameworkDesignError(f"Error occurred for CustomPosixPath.exists():\n{output}")
-        return outcome.return_code == 0
+        # level= when DisableLogger has that constuructor
+        import inspect
+
+        has_level = "level" in inspect.signature(DisableLogger.__init__).parameters
+        params = {"level": log_levels.OUT} if has_level else {}
+        with DisableLogger(**params):  # it will hide logging output from executed command line
+            outcome = self._owner.execute_command(f"ls {self}", expected_return_codes=None)
+            output = outcome.stderr if outcome._stderr is not None else outcome.stdout
+            if "permission denied".casefold() in output.casefold():
+                raise ModuleFrameworkDesignError(f"Error occurred for CustomPosixPath.exists():\n{output}")
+            return outcome.return_code == 0
 
     def expanduser(self) -> CustomPath:  # noqa:D102
         homedir = self._owner.execute_command(

--- a/tests/unit/test_mfd_connect/test_pathlib/test_path.py
+++ b/tests/unit/test_mfd_connect/test_pathlib/test_path.py
@@ -4,6 +4,7 @@ import sys
 from textwrap import dedent
 
 import pytest
+from mfd_common_libs import log_levels
 from mfd_typing.os_values import OSName, OSType
 
 from mfd_connect.base import ConnectionCompletedProcess
@@ -130,6 +131,36 @@ class TestCustomPosixPath:
         )
         with pytest.raises(ModuleFrameworkDesignError):
             custom_posix_path.exists()
+
+    def test_exists_uses_disable_logger_with_level_when_param_present(self, custom_posix_path, mocker):
+        custom_posix_path._owner.execute_command.return_value = ConnectionCompletedProcess(
+            return_code=0, args="command", stdout="stdout", stderr="stderr"
+        )
+        mock_sig = mocker.Mock()
+        mock_sig.parameters = {"self": None, "level": None}
+        mocker.patch("inspect.signature", return_value=mock_sig)
+        mock_disable_logger = mocker.patch("mfd_connect.pathlib.path.DisableLogger")
+        mock_disable_logger.return_value.__enter__ = mocker.Mock(return_value=None)
+        mock_disable_logger.return_value.__exit__ = mocker.Mock(return_value=False)
+
+        custom_posix_path.exists()
+
+        mock_disable_logger.assert_called_once_with(level=log_levels.OUT)
+
+    def test_exists_uses_disable_logger_without_level_when_param_absent(self, custom_posix_path, mocker):
+        custom_posix_path._owner.execute_command.return_value = ConnectionCompletedProcess(
+            return_code=0, args="command", stdout="stdout", stderr="stderr"
+        )
+        mock_sig = mocker.Mock()
+        mock_sig.parameters = {"self": None}
+        mocker.patch("inspect.signature", return_value=mock_sig)
+        mock_disable_logger = mocker.patch("mfd_connect.pathlib.path.DisableLogger")
+        mock_disable_logger.return_value.__enter__ = mocker.Mock(return_value=None)
+        mock_disable_logger.return_value.__exit__ = mocker.Mock(return_value=False)
+
+        custom_posix_path.exists()
+
+        mock_disable_logger.assert_called_once_with()
 
     @pytest.mark.skipif(sys.version_info > (3, 12), reason="requires python3.11 or lower")
     def test_expanduser_pre312(self, mocker):


### PR DESCRIPTION
This pull request updates the `CustomPosixPath.exists()` method to suppress logging output more robustly by using the `DisableLogger` context manager with optional parameters, depending on its constructor signature. It also adds comprehensive tests to verify this behavior.

### Logging control improvements

* Updated `CustomPosixPath.exists()` to use `DisableLogger` with the `level` parameter if supported, ensuring that logging output is properly suppressed during command execution. The method now dynamically checks for the presence of the `level` parameter in `DisableLogger`'s constructor using `inspect.signature`.
* Added `DisableLogger` to the imports in `mfd_connect/pathlib/path.py` to support the new logging control logic.

### Testing enhancements

* Added two unit tests to verify that `CustomPosixPath.exists()` uses `DisableLogger` with or without the `level` parameter, depending on the constructor signature. These tests use mocking to simulate different signatures and assert correct usage.
* Added `log_levels` import to the test file to support the new tests.