### PR TITLE
feat: Added option to run rshell server as module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,11 @@ If code cannot establish connection, it will start deployment of python using [D
 
 `rshell.py` is a Connection class that calls RESTful API endpoints provided by `rshell_server.py` to execute commands on the EFI Shell target system. If required, starts `rshell_server.py` on the host machine.
 
+RShell server can be started manually using the following command:
+```bash
+python -m mfd_connect.rshell_server
+```
+
 ## OS supported:
 * LNX
 * WINDOWS

--- a/mfd_connect/local.py
+++ b/mfd_connect/local.py
@@ -314,6 +314,9 @@ class LocalConnection(PythonConnection):
         stdout, stderr = self._resolve_process_output_arguments(
             stderr_to_stdout=stderr_to_stdout, discard_stdout=discard_stdout, discard_stderr=discard_stderr
         )
+
+        command = self._adjust_command(command)
+
         logger.log(level=log_levels.CMD, msg=f"Starting process >{self._ip}> '{command}', cwd: {cwd}")
         if cwd:
             if self._os_type == OSType.WINDOWS:

--- a/mfd_connect/rshell.py
+++ b/mfd_connect/rshell.py
@@ -105,8 +105,17 @@ class RShellConnection(Connection):
     def _run_server(self) -> RemoteProcess:
         """Run RShell server locally."""
         conn = LocalConnection()
-        server_file = conn.path(__file__).parent / "rshell_server.py"
-        return conn.start_process(f"{conn.modules().sys.executable} {server_file}")
+        conn.enable_sudo()
+        process = conn.start_process(f"{conn.modules().sys.executable} -m mfd_connect.rshell_server")
+        conn.disable_sudo()
+        timeout = TimeoutCounter(1)
+        while not timeout:
+            if not process.running:
+                raise RuntimeError(
+                    f"RShell server failed to start. Exit code: {process.return_code}\n"
+                    f"STDOUT: {process.stdout_text}\nSTDERR: {process.stderr_text}"
+                )
+        return process
 
     def execute_command(
         self,
@@ -246,7 +255,7 @@ class RShellConnection(Connection):
         """Check if EFI shell is the client OS."""
         efi_shell_check_command = "ver"
         output = self.execute_command(
-            efi_shell_check_command, shell=False, expected_return_codes=None, timeout=10
+            efi_shell_check_command, shell=False, expected_return_codes=None, timeout=20
         ).stdout
         return any(out in output for out in ["UEFI Shell", "UEFI Interactive Shell"])
 

--- a/mfd_connect/rshell.py
+++ b/mfd_connect/rshell.py
@@ -3,7 +3,6 @@
 """RShell Connection Class."""
 
 import logging
-from socket import timeout
 import sys
 import time
 import typing
@@ -18,7 +17,6 @@ from mfd_typing.os_values import OSBitness, OSName, OSType
 from mfd_connect.exceptions import ConnectionCalledProcessError, OsNotSupported
 from mfd_connect.local import LocalConnection
 from mfd_connect.pathlib.path import CustomPath, custom_path_factory
-from mfd_connect.process.base import RemoteProcess
 from mfd_connect.process.local.base import LocalProcess
 from mfd_connect.util.decorators import conditional_cache
 from mfd_connect.util.process_utils import kill_process_by_pid
@@ -64,7 +62,7 @@ class RShellConnection(Connection):
         super().__init__(model=model, cache_system_data=cache_system_data)
         self._ip = ip
         self.server_ip = server_ip
-        self.server_process = None
+        self.server_process: LocalProcess | None = None
         if server_ip == "127.0.0.1":
             # start Rshell server
             self.server_process = self._run_server()
@@ -105,7 +103,7 @@ class RShellConnection(Connection):
         if stop_server and self.server_process:
             self.stop_server()
 
-    def _run_server(self) -> RemoteProcess:
+    def _run_server(self) -> LocalProcess:
         """Run RShell server locally."""
         conn = LocalConnection()
         conn.enable_sudo()

--- a/mfd_connect/rshell.py
+++ b/mfd_connect/rshell.py
@@ -3,6 +3,7 @@
 """RShell Connection Class."""
 
 import logging
+from socket import timeout
 import sys
 import time
 import typing
@@ -18,7 +19,9 @@ from mfd_connect.exceptions import ConnectionCalledProcessError, OsNotSupported
 from mfd_connect.local import LocalConnection
 from mfd_connect.pathlib.path import CustomPath, custom_path_factory
 from mfd_connect.process.base import RemoteProcess
+from mfd_connect.process.local.base import LocalProcess
 from mfd_connect.util.decorators import conditional_cache
+from mfd_connect.util.process_utils import kill_process_by_pid
 
 from .base import Connection, ConnectionCompletedProcess
 
@@ -106,7 +109,7 @@ class RShellConnection(Connection):
         """Run RShell server locally."""
         conn = LocalConnection()
         conn.enable_sudo()
-        process = conn.start_process(f"{conn.modules().sys.executable} -m mfd_connect.rshell_server")
+        process: LocalProcess = conn.start_process(f"{conn.modules().sys.executable} -m mfd_connect.rshell_server")
         conn.disable_sudo()
         timeout = TimeoutCounter(1)
         while not timeout:
@@ -325,6 +328,23 @@ class RShellConnection(Connection):
         """Stop the RShell server."""
         if self.server_process:
             logger.log(level=log_levels.MODULE_DEBUG, msg="Stopping RShell server")
-            self.server_process.kill()
+            conn = LocalConnection()
+            conn.enable_sudo()
+            kill_process_by_pid(conn, self.server_process.pid)
+            timeout = TimeoutCounter(10)
+            conn.disable_sudo()
+            while not timeout:
+                if not self.server_process.running:
+                    break
+                time.sleep(1)
+            else:
+                logger.log(level=log_levels.MODULE_DEBUG, msg="RShell server did not stop within timeout")
+                raise RuntimeError("RShell server did not stop within timeout")
+
             logger.log(level=log_levels.MODULE_DEBUG, msg="RShell server stopped")
-            logger.log(level=log_levels.MODULE_DEBUG, msg=self.server_process.stdout_text)
+            logger.log(
+                level=log_levels.MODULE_DEBUG,
+                msg=self.server_process.stdout_text
+                if self.server_process.stdout_text
+                else "RShell server had no stdout",
+            )

--- a/mfd_connect/rshell_server/__init__.py
+++ b/mfd_connect/rshell_server/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: MIT
+"""Module for sample rshell server."""

--- a/mfd_connect/rshell_server/__main__.py
+++ b/mfd_connect/rshell_server/__main__.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: MIT
+"""Module for running rshell_server via module."""
+
+from mfd_connect.rshell_server import rshell_server
+
+if __name__ == "__main__":
+    # execute only if run as a script
+    rshell_server.run()

--- a/mfd_connect/rshell_server/rshell_server.py
+++ b/mfd_connect/rshell_server/rshell_server.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: MIT
 """
 RShell Server Script.
@@ -172,6 +172,11 @@ def post_result() -> Response:
     return Response("Results received", status=200)
 
 
-if __name__ == "__main__":
+def run() -> None:
+    """Run the Flask REST server."""
     print("Starting Flask REST server...")
     app.run(host="0.0.0.0", port=80)
+
+
+if __name__ == "__main__":
+    run()

--- a/mfd_connect/util/process_utils.py
+++ b/mfd_connect/util/process_utils.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 add_logging_level(level_name="MODULE_DEBUG", level_value=log_levels.MODULE_DEBUG)
 
-linux_kill_signal = "SIGINT"
+linux_kill_signal = "SIGTERM"
 
 
 def get_process_by_name(conn: "Connection", process_name: str) -> List[str]:
@@ -56,6 +56,26 @@ def kill_process_by_name(conn: "Connection", process_name: str) -> None:
         return _kill_process_by_name_freebsd(conn=conn, process_name=process_name)
     if os_name == OSName.ESXI:
         return _kill_process_by_name_esxi(conn=conn, process_name=process_name)
+    raise NotImplementedError(f"Not Implemented for {os_name} OS")
+
+
+def kill_process_by_pid(conn: "Connection", pid: int) -> None:
+    """
+    Kill process with given PID.
+
+    :param conn: Connection object
+    :param pid: process ID to kill
+    :raises NotImplementedError when connection obj is of OS other than LINUX, WINDOWS, FREEBSD, ESXI
+    """
+    os_name = conn.get_os_name()
+    if os_name == OSName.LINUX:
+        return _kill_process_by_pid_linux(conn=conn, pid=pid)
+    if os_name == OSName.WINDOWS:
+        return _kill_process_by_pid_windows(conn=conn, pid=pid)
+    if os_name == OSName.FREEBSD:
+        return _kill_process_by_pid_freebsd(conn=conn, pid=pid)
+    if os_name == OSName.ESXI:
+        return _kill_process_by_pid_esxi(conn=conn, pid=pid)
     raise NotImplementedError(f"Not Implemented for {os_name} OS")
 
 
@@ -100,6 +120,16 @@ def _kill_process_by_name_esxi(conn: "Connection", process_name: str) -> None:
         conn.execute_command(command, shell=True)
 
 
+def _kill_process_by_pid_esxi(conn: "Connection", pid: int) -> None:
+    """
+    Kill process with given PID.
+
+    :param conn: Connection object
+    :param pid: process ID to kill
+    """
+    conn.execute_command(f"kill {pid}", shell=True)
+
+
 def _get_process_by_name_freebsd(conn: "Connection", process_name: str) -> List[str]:
     """
     Get Process ids of running processes with given name.
@@ -126,6 +156,16 @@ def _kill_process_by_name_freebsd(conn: "Connection", process_name: str) -> None
     for pid in _get_process_by_name_freebsd(conn=conn, process_name=process_name):
         command = f"kill {pid}"
         conn.execute_command(command)
+
+
+def _kill_process_by_pid_freebsd(conn: "Connection", pid: int) -> None:
+    """
+    Kill process with given PID.
+
+    :param conn: Connection object
+    :param pid: process ID to kill
+    """
+    conn.execute_command(f"kill {pid}")
 
 
 def _get_process_by_name_linux(conn: "Connection", process_name: str) -> List[str]:
@@ -157,6 +197,21 @@ def _kill_process_by_name_linux(conn: "Connection", process_name: str) -> None:
         return
     elif res.return_code == 1:
         raise ProcessNotRunning(f"Process {process_name} not running!")
+
+
+def _kill_process_by_pid_linux(conn: "Connection", pid: int) -> None:
+    """
+    Kill process with given PID.
+
+    :param conn: Connection object
+    :param pid: process ID to kill
+    :raises ProcessNotRunning when the process not running
+    """
+    res = conn.execute_command(f"kill -{linux_kill_signal} {pid}", expected_return_codes={0, 1}, shell=True)
+    if res.return_code == 0:
+        return
+    elif res.return_code == 1:
+        raise ProcessNotRunning(f"Process {pid} not running!")
 
 
 def _get_process_by_name_windows(conn: "Connection", process_name: str) -> List[str]:
@@ -195,6 +250,27 @@ def _kill_process_by_name_windows(conn: "Connection", process_name: str) -> None
                 )
             else:
                 raise Exception(f"Error occurred while killing the process, {out.stderr}")
+
+
+def _kill_process_by_pid_windows(conn: "Connection", pid: int) -> None:
+    """
+    Kill process with given PID.
+
+    :param conn: Connection object
+    :param pid: process ID to kill
+    """
+    out = conn.execute_powershell(
+        f"taskkill /f /t /pid {pid}",
+        expected_return_codes={0, 1},
+    )
+    if out.return_code == 1:
+        if "not found" in out.stderr:
+            logger.log(
+                level=log_levels.MODULE_DEBUG,
+                msg=out.stderr,
+            )
+        else:
+            raise Exception(f"Error occurred while killing the process, {out.stderr}")
 
 
 def _kill_all_processes_by_name_windows(conn: "Connection", process_name: str) -> None:

--- a/tests/unit/test_mfd_connect/test_rshell.py
+++ b/tests/unit/test_mfd_connect/test_rshell.py
@@ -407,10 +407,16 @@ class TestRShellConnection:
         rshell.server_process = None
         rshell.stop_server()
 
+        local_connection = mocker.patch("mfd_connect.rshell.LocalConnection").return_value
+        kill_process_by_pid = mocker.patch("mfd_connect.rshell.kill_process_by_pid")
         server_process = mocker.Mock()
+        server_process.pid = 1234
+        server_process.running = False
         server_process.stdout_text = "server out"
         rshell.server_process = server_process
 
         rshell.stop_server()
 
-        server_process.kill.assert_called_once()
+        local_connection.enable_sudo.assert_called_once()
+        kill_process_by_pid.assert_called_once_with(local_connection, 1234)
+        local_connection.disable_sudo.assert_called_once()

--- a/tests/unit/test_mfd_connect/test_rshell.py
+++ b/tests/unit/test_mfd_connect/test_rshell.py
@@ -117,18 +117,94 @@ class TestRShellConnection:
 
         rshell.stop_server.assert_not_called()
 
-    def test_run_server(self, rshell, mocker):
+    def test_run_server_success(self, rshell, mocker):
+        """Test successful RShell server startup using module execution."""
+        process = mocker.Mock()
+        process.running = True
+
         conn = mocker.Mock()
-        server_file = Path("C:/tmp/rshell.py")
-        conn.path.return_value = server_file
-        conn.modules().sys.executable = "python_exe"
-        conn.start_process.return_value = "proc"
+        conn.modules().sys.executable = "python"
+        conn.start_process.return_value = process
         mocker.patch("mfd_connect.rshell.LocalConnection", return_value=conn)
+
+        class FakeTimeoutCounter:
+            def __init__(self, _timeout):
+                self.count = 0
+
+            def __bool__(self):
+                self.count += 1
+                return self.count > 0  # exits on first check since process.running is True
+
+        mocker.patch("mfd_connect.rshell.TimeoutCounter", FakeTimeoutCounter)
 
         result = rshell._run_server()
 
-        assert result == "proc"
-        conn.start_process.assert_called_once_with(f"python_exe {server_file.parent / 'rshell_server.py'}")
+        assert result == process
+        conn.start_process.assert_called_once_with("python -m mfd_connect.rshell_server")
+
+    def test_run_server_timeout_loop_executes(self, rshell, mocker):
+        """Test that the timeout loop in _run_server executes at least once."""
+        process = mocker.Mock()
+        process.running = True  # Process is running successfully
+
+        conn = mocker.Mock()
+        conn.modules().sys.executable = "python"
+        conn.start_process.return_value = process
+        mocker.patch("mfd_connect.rshell.LocalConnection", return_value=conn)
+
+        call_count = 0
+
+        class FakeTimeoutCounter:
+            def __init__(self, _timeout):
+                nonlocal call_count
+                call_count = 0
+
+            def __bool__(self):
+                nonlocal call_count
+                call_count += 1
+                # First call: return False so while not timeout is True (loop executes)
+                # Then: return True so loop exits
+                return call_count > 1
+
+        mocker.patch("mfd_connect.rshell.TimeoutCounter", FakeTimeoutCounter)
+
+        result = rshell._run_server()
+
+        assert result == process
+        # Verify the while loop executed at least once
+        assert call_count >= 1
+
+    def test_run_server_server_not_running_raises_error(self, rshell, mocker):
+        """Test error when server process is not running."""
+        process = mocker.Mock()
+        process.running = False  # Process crashed
+        process.return_code = 1
+        process.stdout_text = "stdout output"
+        process.stderr_text = "stderr output"
+
+        conn = mocker.Mock()
+        conn.modules().sys.executable = "python"
+        conn.start_process.return_value = process
+        mocker.patch("mfd_connect.rshell.LocalConnection", return_value=conn)
+
+        call_count = 0
+
+        class FakeTimeoutCounter:
+            def __init__(self, _timeout):
+                nonlocal call_count
+                call_count = 0
+
+            def __bool__(self):
+                nonlocal call_count
+                call_count += 1
+                # First call: return False so while not timeout is True (loop executes once)
+                # The RuntimeError will be raised on the first iteration
+                return call_count > 1
+
+        mocker.patch("mfd_connect.rshell.TimeoutCounter", FakeTimeoutCounter)
+
+        with pytest.raises(RuntimeError, match="RShell server failed to start.*Exit code: 1"):
+            rshell._run_server()
 
     def test_type_checking_import_block_executes(self, monkeypatch):
         class _FakeBaseModel:
@@ -241,6 +317,18 @@ class TestRShellConnection:
 
         assert rshell._check_if_efi_shell() is True
         assert rshell._check_if_efi_shell() is False
+
+    def test_check_if_efi_shell_uses_20_second_timeout(self, rshell, mocker):
+        """Test that _check_if_efi_shell uses 20 second timeout for ver command."""
+        execute_mock = mocker.Mock(
+            return_value=ConnectionCompletedProcess(args="ver", return_code=0, stdout="UEFI Shell v2")
+        )
+        rshell.execute_command = execute_mock
+
+        rshell._check_if_efi_shell()
+
+        # Verify execute_command was called with timeout=20
+        execute_mock.assert_called_once_with("ver", shell=False, expected_return_codes=None, timeout=20)
 
     def test_get_os_type_paths(self, rshell, mocker):
         rshell._check_if_efi_shell = mocker.Mock(side_effect=[True, False, False])

--- a/tests/unit/test_mfd_connect/test_rshell_server.py
+++ b/tests/unit/test_mfd_connect/test_rshell_server.py
@@ -4,19 +4,22 @@
 
 import importlib.util
 import runpy
+import sys
 from pathlib import Path
 
 import pytest
 
 
-SERVER_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "mfd_connect" / "rshell_server.py"
+SERVER_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "mfd_connect" / "rshell_server" / "rshell_server.py"
 
 
 def _load_server_module(module_name: str = "test_rs_server"):
+    """Load the rshell_server module dynamically for testing."""
     spec = importlib.util.spec_from_file_location(module_name, SERVER_SCRIPT_PATH)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
+    sys.modules[module_name] = module
     return module
 
 
@@ -164,6 +167,19 @@ class TestRShellServerScript:
         assert response_given_rc.status_code == 200
         assert server_module.output_queue["cmd-b"].output == "output-b"
         assert server_module.output_queue["cmd-b"].rc == 3
+
+    def test_run_function_starts_flask(self, server_module, monkeypatch):
+        """Test that the run() function starts Flask with correct host and port."""
+        captured = {}
+
+        def _fake_run(self, host, port):
+            captured["host"] = host
+            captured["port"] = port
+
+        monkeypatch.setattr("flask.app.Flask.run", _fake_run)
+        server_module.run()
+
+        assert captured == {"host": "0.0.0.0", "port": 80}
 
     def test_main_block_starts_flask(self, monkeypatch):
         captured = {}

--- a/tests/unit/test_mfd_connect/test_rshell_server_module.py
+++ b/tests/unit/test_mfd_connect/test_rshell_server_module.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: MIT
+"""Tests for RShell server module package."""
+
+import importlib.util
+import runpy
+from pathlib import Path
+
+
+SERVER_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "mfd_connect" / "rshell_server" / "rshell_server.py"
+
+
+def _load_server_module(module_name: str = "test_rs_server"):
+    spec = importlib.util.spec_from_file_location(module_name, SERVER_SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+RSHELL_SERVER_MODULE_PATH = Path(__file__).resolve().parents[3] / "mfd_connect" / "rshell_server"
+RSHELL_SERVER_INIT_PATH = RSHELL_SERVER_MODULE_PATH / "__init__.py"
+RSHELL_SERVER_MAIN_PATH = RSHELL_SERVER_MODULE_PATH / "__main__.py"
+
+
+class TestRShellServerModule:
+    """Tests for RShell server module package."""
+
+    def test_rshell_server_init_exists(self):
+        """Test that __init__.py file exists in rshell_server package."""
+        assert RSHELL_SERVER_INIT_PATH.exists()
+
+    def test_rshell_server_main_exists(self):
+        """Test that __main__.py file exists in rshell_server package."""
+        assert RSHELL_SERVER_MAIN_PATH.exists()
+
+    def test_rshell_server_module_init_has_docstring(self):
+        """Test that __init__.py has proper module documentation."""
+        with open(RSHELL_SERVER_INIT_PATH) as f:
+            content = f.read()
+        assert '"""Module for sample rshell server."""' in content
+
+    def test_rshell_server_main_imports_run(self):
+        """Test that __main__.py imports run function from rshell_server.rshell_server."""
+        with open(RSHELL_SERVER_MAIN_PATH) as f:
+            content = f.read()
+        assert "from mfd_connect.rshell_server import rshell_server" in content
+        assert "rshell_server.run()" in content
+
+    def test_rshell_server_run_function_callable(self):
+        """Test that run function is callable in loaded rshell_server."""
+        server_module = _load_server_module()
+        assert hasattr(server_module, "run")
+        assert callable(server_module.run)
+
+    def test_rshell_server_init_module_import(self):
+        """Test that rshell_server package __init__ can be imported."""
+        # Import the rshell_server package - this executes __init__.py
+        import mfd_connect.rshell_server as rs_module
+
+        # Verify the module exists and has the expected docstring
+        assert rs_module.__doc__
+        assert "rshell server" in rs_module.__doc__.lower()
+
+    def test_rshell_server_main_module_callable(self):
+        """Test that run function exists in rshell_server.py module."""
+        # Load the rshell_server.py file from within the package
+        server_module = _load_server_module()
+
+        # Verify it has the run function
+        assert hasattr(server_module, "run"), "rshell_server.py should have run function"
+        assert callable(server_module.run), "run should be callable"
+
+    def test_rshell_server_main_execute_as_script(self, mocker):
+        """Test __main__.py when executed as a script (if __name__ == '__main__')."""
+        # Mock Flask to prevent server startup
+        mocker.patch("flask.Flask")
+
+        # Read and execute __main__.py content with __name__ = "__main__"
+        # The __main__.py should import from the package and call run()
+        mock_run = mocker.Mock()
+        mocker.patch("mfd_connect.rshell_server.rshell_server.run", mock_run)
+
+        # Execute __main__.py as if it were the main module
+        try:
+            runpy.run_path(str(RSHELL_SERVER_MAIN_PATH), run_name="__main__")
+        except (AttributeError, SystemExit):
+            # In case the run() function triggers Flask startup or errors
+            # This is expected since run is mocked
+            pass

--- a/tests/unit/test_mfd_connect/test_utils/test_process_utils.py
+++ b/tests/unit/test_mfd_connect/test_utils/test_process_utils.py
@@ -18,6 +18,7 @@ from mfd_typing.os_values import OSName
 from mfd_connect.util.process_utils import (
     get_process_by_name,
     kill_process_by_name,
+    kill_process_by_pid,
     kill_all_processes_by_name,
     stop_process_by_name,
 )
@@ -75,13 +76,25 @@ class TestProcessUtils:
         ]
         kill_process_by_name(conn=ssh_linux, process_name="tcpdump")
         ssh_linux.execute_command.assert_called_once_with(
-            "pkill tcpdump --signal SIGINT", expected_return_codes={0, 1}, shell=True
+            "pkill tcpdump --signal SIGTERM", expected_return_codes={0, 1}, shell=True
         )
 
     def test_kill_process_by_name_using_kill_linux(self, ssh_linux):
         ssh_linux.execute_command.return_value = ConnectionCompletedProcess(args="", stdout="", return_code=1)
         with pytest.raises(ProcessNotRunning, match="Process tcpdump not running!"):
             kill_process_by_name(conn=ssh_linux, process_name="tcpdump")
+
+    def test_kill_process_by_pid_linux(self, ssh_linux):
+        ssh_linux.execute_command.return_value = ConnectionCompletedProcess(args="", stdout="", return_code=0)
+        kill_process_by_pid(conn=ssh_linux, pid=1234)
+        ssh_linux.execute_command.assert_called_once_with(
+            "kill -SIGTERM 1234", expected_return_codes={0, 1}, shell=True
+        )
+
+    def test_kill_process_by_pid_not_running_error_linux(self, ssh_linux):
+        ssh_linux.execute_command.return_value = ConnectionCompletedProcess(args="", stdout="", return_code=1)
+        with pytest.raises(ProcessNotRunning, match="Process 1234 not running!"):
+            kill_process_by_pid(conn=ssh_linux, pid=1234)
 
     def test_get_process_by_name_windows(self, ssh_windows):
         get_process_out = dedent(
@@ -138,6 +151,11 @@ class TestProcessUtils:
             ]
         )
 
+    def test_kill_process_by_pid_windows(self, ssh_windows):
+        ssh_windows.execute_powershell.return_value = ConnectionCompletedProcess(args="", stdout="", return_code=0)
+        kill_process_by_pid(conn=ssh_windows, pid=1234)
+        ssh_windows.execute_powershell.assert_called_once_with("taskkill /f /t /pid 1234", expected_return_codes={0, 1})
+
     def test_kill_all_processes_by_name_windows(self, ssh_windows):
         ssh_windows.execute_powershell.return_value = ConnectionCompletedProcess(args="", stdout="", return_code=0)
         kill_all_processes_by_name(conn=ssh_windows, process_name="explorer.exe")
@@ -179,6 +197,10 @@ class TestProcessUtils:
             ]
         )
 
+    def test_kill_process_by_pid_esxi(self, ssh_esxi):
+        kill_process_by_pid(conn=ssh_esxi, pid=1234)
+        ssh_esxi.execute_command.assert_called_once_with("kill 1234", shell=True)
+
     def test_get_process_by_name_freebsd(self, ssh_freebsd):
         ps_output = dedent(
             """\
@@ -217,9 +239,17 @@ class TestProcessUtils:
             ]
         )
 
+    def test_kill_process_by_pid_freebsd(self, ssh_freebsd):
+        kill_process_by_pid(conn=ssh_freebsd, pid=1234)
+        ssh_freebsd.execute_command.assert_called_once_with("kill 1234")
+
     def test_get_process_by_name_process_efi(self, ssh_efishell, mocker):
         with pytest.raises(NotImplementedError, match=f"Not Implemented for {ssh_efishell.get_os_name()} OS"):
             get_process_by_name(conn=ssh_efishell, process_name="tcpdump")
+
+    def test_kill_process_by_pid_process_efi(self, ssh_efishell):
+        with pytest.raises(NotImplementedError, match=f"Not Implemented for {ssh_efishell.get_os_name()} OS"):
+            kill_process_by_pid(conn=ssh_efishell, pid=1234)
 
     def test_stop_process_not_running(self, mocker, ssh_linux, caplog):
         caplog.set_level(log_levels.MODULE_DEBUG)


### PR DESCRIPTION
This pull request refactors the RShell server to support Python module execution, improves startup reliability, and enhances test coverage. The main changes include moving the RShell server to a package for module execution, updating the startup logic to use `python -m`, adding new tests to cover the updated logic, and improving documentation.

**RShell Server Packaging and Startup Improvements:**
- The RShell server has been moved into a package (`mfd_connect/rshell_server/`) to allow starting it with `python -m mfd_connect.rshell_server`, and the startup logic in `rshell.py` was updated to use this approach for improved reliability and cross-platform compatibility. [[1]](diffhunk://#diff-046f726b26f55b541c6dceedefa3dbdd63da16fce2d0953a74a0f92e2abc101eL1-R1) [[2]](diffhunk://#diff-046f726b26f55b541c6dceedefa3dbdd63da16fce2d0953a74a0f92e2abc101eL175-R182) [[3]](diffhunk://#diff-6b5687b77012d0e241faa091971ac7e8e42179922a98b4b29b7b7c8f11fde57eR1-R9) [[4]](diffhunk://#diff-9340e41303868c3e0917a2cc92efbff35114cda6e9ba7cf5e89ad599b7d893ceL108-R116) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1192-R1196)

**Testing Enhancements:**
- Comprehensive unit tests were added and updated to cover the new server startup logic, including tests for successful startup, timeout handling, and error conditions when the server fails to start. [[1]](diffhunk://#diff-dca97329b2fe1c3dd92c65b0ea3991c974bca1c3bd9755fcc502f3f775ff4078L120-R209) [[2]](diffhunk://#diff-dca97329b2fe1c3dd92c65b0ea3991c974bca1c3bd9755fcc502f3f775ff4078R323-R336)
- New tests were added to verify the existence and correctness of the `rshell_server` package structure and its entry points, ensuring that the package can be imported and executed as a module.

**Timeout and Reliability Adjustments:**
- The timeout for the EFI shell check command was increased from 10 to 20 seconds to improve reliability on slow systems, and this behavior is now explicitly tested. [[1]](diffhunk://#diff-9340e41303868c3e0917a2cc92efbff35114cda6e9ba7cf5e89ad599b7d893ceL249-R256) [[2]](diffhunk://#diff-dca97329b2fe1c3dd92c65b0ea3991c974bca1c3bd9755fcc502f3f775ff4078R323-R336)

**Documentation Updates:**
- The `README.md` was updated to document the new way to manually start the RShell server using the module execution command.
- Added docstrings and copyright/license headers to new and updated files. [[1]](diffhunk://#diff-2a45cad72a466db9b0247466c4cd5e59631d38de5f16c64cb13c7f8ae4bdeb05R1-R4) [[2]](diffhunk://#diff-6b5687b77012d0e241faa091971ac7e8e42179922a98b4b29b7b7c8f11fde57eR1-R9) [[3]](diffhunk://#diff-50eb30d54302eacc297ab3fedc5c281750ffa6df0d5420af4c20d7f9cf393df0R1-R95)

**Test Infrastructure Maintenance:**
- Test scripts were updated to reflect the new package structure, ensuring dynamic imports and path references work correctly with the refactored server code. [[1]](diffhunk://#diff-48db5dca75a0d2f1b280d0da78449debe3c5551fe712716fdec89273505ce76bR7-R23) [[2]](diffhunk://#diff-48db5dca75a0d2f1b280d0da78449debe3c5551fe712716fdec89273505ce76bR172-R184)

These changes modernize the RShell server's deployment, improve testability, and enhance reliability across platforms.