### PR TITLE
fix: Terminate RPyC process pipe-drain watcher threads on stop/kill

### DIFF
--- a/mfd_connect/process/rpyc/base.py
+++ b/mfd_connect/process/rpyc/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: MIT
 """Module for RPyC-specific RPyCProcess implementation."""
 
@@ -7,9 +7,9 @@ import typing
 from abc import abstractmethod
 from contextlib import suppress
 from signal import Signals, SIGTERM
-from threading import Lock
+from threading import Event, Lock
 from time import sleep
-from typing import IO, Optional, Iterator, Callable, Type, ClassVar
+from typing import IO, Any, Optional, Iterator, Callable, ClassVar
 
 
 from mfd_common_libs import TimeoutCounter, log_levels
@@ -20,7 +20,6 @@ from mfd_connect.exceptions import (
     RemoteProcessStreamNotAvailable,
     RemoteProcessInvalidState,
 )
-from mfd_connect.util import BatchQueue
 from ..base import RemoteProcess
 
 
@@ -45,6 +44,10 @@ class RPyCProcess(RemoteProcess):
 
     POOL_INTERVAL = 0.1
     """Interval for polling operations."""
+    PIPE_DRAIN_TIMEOUT = 30
+    """Seconds without new output after which a not-yet-EOF watcher is treated as stuck and stopped."""
+    PIPE_DRAIN_MAX_TIMEOUT = 600
+    """Absolute cap (seconds) on draining a single stream, so a child streaming output forever can't hang stop()."""
     _os_type: ClassVar[OSType] = None
     _os_names: ClassVar[typing.List[OSName]] = None
 
@@ -75,50 +78,88 @@ class RPyCProcess(RemoteProcess):
 
         self._cached_stdout_queue = None
         self._stdout_queue_cache_lock = Lock()
+        self._cached_stdout_stop_event = None
+        self._cached_stdout_done_event = None
 
         self._cached_stdout_iter = None
         self._stdout_iter_cache_lock = Lock()
 
         self._cached_stderr_queue = None
         self._stderr_queue_cache_lock = Lock()
+        self._cached_stderr_stop_event = None
+        self._cached_stderr_done_event = None
 
         self._cached_stderr_iter = None
         self._stderr_iter_cache_lock = Lock()
 
     @staticmethod
-    def _get_process_io_queue(process_io: IO, bq: Type[BatchQueue]) -> BatchQueue:
+    def _get_process_io_queue(process_io: IO) -> "tuple[Any, Event, Event]":
         """
-        Wrap process' IO stream in a line-by-line queue.
+        Wrap process' IO stream in a remote-side, batch-drainable buffer.
 
-        Unlike IO stream - resulting queue can be used to peek if new output lines are available.
-        This gives the ability to periodically poll the queue for new results, not blocking the RPyC connection.
+        A watcher thread and the buffer are created on the *remote* side (this method is teleported), so
+        reading the process' stream and buffering its lines happens locally on the remote host - no RPyC
+        traffic per line. The returned drainer exposes ``drain()``, which pops all currently buffered text
+        and returns it as a single string together with an EOF flag; because a ``(str, bool)`` tuple is
+        passed by value, the whole backlog crosses the connection in a single round-trip instead of one
+        round-trip per line. This is what keeps stopping large-output processes fast (the previous
+        line-by-line callback design cost one RPyC round-trip per output line).
 
-        This method is teleported to the remote machine before usage, resulting the queue to be created on the
-        remote side of the connection as well.
+        Two events are also created on the remote side:
+        - ``done_event`` is set once the watcher reaches stream EOF (all output buffered).
+        - ``stop_event`` can be set (via :meth:`_stop_pipe_drain`) to make the watcher stop reading, so it
+          can't keep a detached child's pipe drained forever and grow the remote buffer without bound.
 
-        :param bq: BatchQueue class
         :param process_io: IO object to wrap around (stdout or stderr).
-        :return: Queue wrapped around stdout.readline() call.
+        :return: Tuple of (remote drainer, remote stop event, remote done event).
         """
         import threading
 
-        q = bq()
+        buffer = []
+        buffer_lock = threading.Lock()
+        produced = [0]
+        finished = [False]
+        stop_event = threading.Event()
+        done_event = threading.Event()
+
+        class _RemoteDrainer:
+            """Remote-side buffer whose drain() returns all buffered text at once (bulk, by value)."""
+
+            def drain(self) -> "tuple[str, bool]":
+                with buffer_lock:
+                    text = "".join(buffer)
+                    buffer.clear()
+                    return text, finished[0]
+
+            def progress(self) -> int:
+                return produced[0]
 
         def _watcher() -> None:
             try:
                 with process_io:
                     for line in process_io:
-                        q.put(line)
+                        with buffer_lock:
+                            buffer.append(line)
+                            produced[0] += 1
+                        if stop_event.is_set():
+                            break
             except Exception:
-                q.put("<internal>: Error occurred during io processing. Check responder log for details.")
-                raise
+                if not stop_event.is_set():
+                    with buffer_lock:
+                        buffer.append(
+                            "<internal>: Error occurred during io processing. Check responder log for details."
+                        )
+                        produced[0] += 1
+                    raise
             finally:
-                q.put(None)
+                with buffer_lock:
+                    finished[0] = True
+                done_event.set()
 
         stdout_watcher = threading.Thread(target=_watcher, daemon=True)
         stdout_watcher.start()
 
-        return q
+        return _RemoteDrainer(), stop_event, done_event
 
     @property
     def _remote_get_process_io_queue(self) -> Callable:
@@ -129,19 +170,27 @@ class RPyCProcess(RemoteProcess):
         return self._cached_remote_get_process_io_queue
 
     @property
-    def _stdout_queue(self) -> BatchQueue:
-        """Stdout line-by-line queue."""
+    def _stdout_queue(self) -> Any:
+        """Remote-side stdout drainer (see :meth:`_get_process_io_queue`)."""
         with self._stdout_queue_cache_lock:
             if self._cached_stdout_queue is None:
-                self._cached_stdout_queue = self._remote_get_process_io_queue(self.stdout_stream, BatchQueue)
+                (
+                    self._cached_stdout_queue,
+                    self._cached_stdout_stop_event,
+                    self._cached_stdout_done_event,
+                ) = self._remote_get_process_io_queue(self.stdout_stream)
         return self._cached_stdout_queue
 
     @property
-    def _stderr_queue(self) -> BatchQueue:
-        """Stderr line-by-line queue."""
+    def _stderr_queue(self) -> Any:
+        """Remote-side stderr drainer (see :meth:`_get_process_io_queue`)."""
         with self._stderr_queue_cache_lock:
             if self._cached_stderr_queue is None:
-                self._cached_stderr_queue = self._remote_get_process_io_queue(self.stderr_stream, BatchQueue)
+                (
+                    self._cached_stderr_queue,
+                    self._cached_stderr_stop_event,
+                    self._cached_stderr_done_event,
+                ) = self._remote_get_process_io_queue(self.stderr_stream)
         return self._cached_stderr_queue
 
     @property
@@ -153,27 +202,34 @@ class RPyCProcess(RemoteProcess):
         """
         return self._process.pid
 
-    def _iterate_non_blocking_queue(self, q: BatchQueue) -> Iterator[str]:
+    def _iterate_non_blocking_queue(self, drainer: Any) -> Iterator[str]:
         """
-        Get polling iterator over a non-blocking queue.
+        Get a polling line iterator over a remote drainer.
 
-        Used to get a line-by-line iterator for process' IO streams which doesn't block the connection.
-        :param q: BatchQueue to iterate over.
-        :return: Resulting iterator.
+        Pulls buffered text from the remote side in bulk (one round-trip per poll, not per line) and
+        splits it back into lines locally, so the iterator does not block the RPyC connection.
+
+        :param drainer: Remote drainer returned by :meth:`_get_process_io_queue`.
+        :return: Resulting line iterator.
         """
+        partial = ""
         while True:
-            lines = q.get_many()
+            text, done = drainer.drain()
 
-            if len(lines) == 0:
-                # No lines readily available
+            if text:
+                partial += text
+                chunks = partial.split("\n")
+                partial = chunks.pop()  # trailing text after the last newline (incomplete line)
+                for chunk in chunks:
+                    yield chunk + "\n"
+            elif done:
+                # EOF reached and nothing left buffered - emit any trailing partial line and stop.
+                if partial:
+                    yield partial
+                return
+            else:
+                # No output readily available
                 sleep(self.POOL_INTERVAL)
-                continue
-
-            for line in lines:
-                if line is None:
-                    # None is the last item in a queue, terminating iterator
-                    return
-                yield line
 
     @property
     def running(self) -> bool:  # noqa D102
@@ -256,6 +312,7 @@ class RPyCProcess(RemoteProcess):
 
         if wait is not None:
             self.wait(timeout=wait)
+            self._stop_pipe_drain()
 
     @abstractmethod
     def stop(self, wait: Optional[int] = 60) -> None:  # noqa D102
@@ -279,6 +336,59 @@ class RPyCProcess(RemoteProcess):
 
         with suppress(RemoteProcessStreamNotAvailable):
             _ = self._stderr_queue  # noqa F841
+
+    def _stop_pipe_drain(self, idle_timeout: Optional[float] = None, max_timeout: Optional[float] = None) -> None:
+        """
+        Stop stdout/stderr pipe-drain watcher threads started by :meth:`_start_pipe_drain`.
+
+        Waits for each watcher to reach stream EOF (all buffered output drained), so any output the
+        process emits after the stop signal - e.g. a traffic summary at the end of a large backlog - is
+        fully captured, matching the behaviour of the SSH connection. The wait is bounded by output
+        *inactivity*: as long as new lines keep arriving the drain keeps waiting, no matter how big the
+        backlog or how small the caller's ``wait`` was. A stream is only given up on when either it
+        produces no new output for ``idle_timeout`` seconds without reaching EOF (typically a detached
+        child keeping the pipe open), or the absolute ``max_timeout`` cap is hit (a detached child that
+        streams output forever) - in both cases the watcher is signalled to stop so it can't linger and
+        congest the shared RPyC connection, nor hang ``stop``/``kill`` indefinitely.
+
+        Should be called once the process has been confirmed finished (e.g. after a successful ``wait``).
+
+        :param idle_timeout: Seconds of no new output after which a not-yet-EOF watcher is stopped.
+                             Defaults to :attr:`PIPE_DRAIN_TIMEOUT`.
+        :param max_timeout: Absolute cap in seconds on draining a single stream, regardless of activity.
+                            Defaults to :attr:`PIPE_DRAIN_MAX_TIMEOUT`.
+        """
+        if idle_timeout is None:
+            idle_timeout = self.PIPE_DRAIN_TIMEOUT
+        if max_timeout is None:
+            max_timeout = self.PIPE_DRAIN_MAX_TIMEOUT
+
+        for queue_attr, stop_attr, done_attr in (
+            ("_cached_stdout_queue", "_cached_stdout_stop_event", "_cached_stdout_done_event"),
+            ("_cached_stderr_queue", "_cached_stderr_stop_event", "_cached_stderr_done_event"),
+        ):
+            drainer = getattr(self, queue_attr)
+            stop_event = getattr(self, stop_attr)
+            done_event = getattr(self, done_attr)
+            if drainer is None or stop_event is None or done_event is None:
+                continue
+            with suppress(Exception):
+                last_progress = None
+                idle = TimeoutCounter(idle_timeout)
+                hard_cap = TimeoutCounter(max_timeout)
+                while not done_event.is_set():
+                    progress = drainer.progress()
+                    if progress != last_progress:
+                        # Output is still being buffered - keep waiting and reset the inactivity timer.
+                        last_progress = progress
+                        idle = TimeoutCounter(idle_timeout)
+                    if idle or hard_cap:
+                        # No new output for idle_timeout seconds (detached child keeping the pipe open),
+                        # or the absolute cap was hit (child streaming output forever) - stop the watcher
+                        # to avoid an unbounded remote buffer and an unbounded wait.
+                        stop_event.set()
+                        break
+                    sleep(self.POOL_INTERVAL)
 
     def _get_and_kill_process(self, with_signal: Optional[typing.Union[Signals, str, int]] = None) -> None:
         """

--- a/mfd_connect/process/rpyc/posix.py
+++ b/mfd_connect/process/rpyc/posix.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: MIT
 """Module for RPyCProcess implementation for POSIX-compliant OS'es."""
 
@@ -31,5 +31,6 @@ class PosixRPyCProcess(RPyCProcess):
 
             if wait is not None:
                 self.wait(timeout=wait)
+                self._stop_pipe_drain()
         else:
             raise RemoteProcessInvalidState("Process has already finished")

--- a/mfd_connect/process/rpyc/windows.py
+++ b/mfd_connect/process/rpyc/windows.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: MIT
 """Module for RPyCProcess implementation for Windows."""
 
@@ -34,6 +34,7 @@ class WindowsRPyCProcess(RPyCProcess):
 
             if wait is not None:
                 self.wait(timeout=wait)
+                self._stop_pipe_drain()
         else:
             raise RemoteProcessInvalidState("Process has already finished")
 

--- a/tests/unit/test_mfd_connect/test_process/test_rpyc/test_base.py
+++ b/tests/unit/test_mfd_connect/test_process/test_rpyc/test_base.py
@@ -17,7 +17,6 @@ import threading
 import pytest
 from io import TextIOWrapper
 from subprocess import Popen
-from mfd_connect.util import BatchQueue
 
 
 class TestRPyCProcess:
@@ -71,9 +70,17 @@ class TestRPyCProcess:
         rpyc_process._get_process_io_queue = mocker.create_autospec(rpyc_process._get_process_io_queue, spec_set=True)
         rpyc_process._cached_remote_get_process_io_queue = None
         rpyc_process._cached_stdout_queue = None
-        assert rpyc_process._stdout_queue == rpyc_process._remote_get_process_io_queue.return_value
-        print(rpyc_process._remote_get_process_io_queue)
-        rpyc_process._remote_get_process_io_queue.assert_called_once_with(stdout_stream_mock.return_value, BatchQueue)
+        rpyc_process._cached_stdout_stop_event = None
+        rpyc_process._cached_stdout_done_event = None
+        rpyc_process._owner.teleport_function.return_value.return_value = (
+            mocker.sentinel.queue,
+            mocker.sentinel.stop_event,
+            mocker.sentinel.done_event,
+        )
+        assert rpyc_process._stdout_queue == mocker.sentinel.queue
+        assert rpyc_process._cached_stdout_stop_event == mocker.sentinel.stop_event
+        assert rpyc_process._cached_stdout_done_event == mocker.sentinel.done_event
+        rpyc_process._remote_get_process_io_queue.assert_called_once_with(stdout_stream_mock.return_value)
         rpyc_process._stdout_queue_cache_lock.__enter__.assert_called()
         rpyc_process._stdout_queue_cache_lock.__exit__.assert_called()
 
@@ -94,8 +101,17 @@ class TestRPyCProcess:
         rpyc_process._get_process_io_queue = mocker.create_autospec(rpyc_process._get_process_io_queue, spec_set=True)
         rpyc_process._cached_remote_get_process_io_queue = None
         rpyc_process._cached_stderr_queue = None
-        assert rpyc_process._stderr_queue == rpyc_process._remote_get_process_io_queue.return_value
-        rpyc_process._remote_get_process_io_queue.assert_called_once_with(stderr_stream_mock.return_value, BatchQueue)
+        rpyc_process._cached_stderr_stop_event = None
+        rpyc_process._cached_stderr_done_event = None
+        rpyc_process._owner.teleport_function.return_value.return_value = (
+            mocker.sentinel.queue,
+            mocker.sentinel.stop_event,
+            mocker.sentinel.done_event,
+        )
+        assert rpyc_process._stderr_queue == mocker.sentinel.queue
+        assert rpyc_process._cached_stderr_stop_event == mocker.sentinel.stop_event
+        assert rpyc_process._cached_stderr_done_event == mocker.sentinel.done_event
+        rpyc_process._remote_get_process_io_queue.assert_called_once_with(stderr_stream_mock.return_value)
         rpyc_process._stderr_queue_cache_lock.__enter__.assert_called()
         rpyc_process._stderr_queue_cache_lock.__exit__.assert_called()
 
@@ -109,19 +125,17 @@ class TestRPyCProcess:
         rpyc_process._stderr_queue_cache_lock.__exit__.assert_called()
 
     def test__iterate_non_blocking_queue(self, rpyc_process, sleep_mock, mocker):
-        q = mocker.create_autospec(BatchQueue(), spec_set=True)
-        q.get_many.side_effect = [[mocker.sentinel.line1, mocker.sentinel.line2], [], [mocker.sentinel.line3, None]]
+        drainer = mocker.Mock()
+        drainer.drain.side_effect = [
+            ("line1\nline2\n", False),
+            ("", False),
+            ("line3\n", True),
+            ("", True),
+        ]
 
-        assert all(
-            [
-                expect == actual
-                for expect, actual in zip(
-                    [mocker.sentinel.line1, mocker.sentinel.line2, mocker.sentinel.line3],
-                    rpyc_process._iterate_non_blocking_queue(q),
-                )
-            ]
-        )
+        result = list(rpyc_process._iterate_non_blocking_queue(drainer))
 
+        assert result == ["line1\n", "line2\n", "line3\n"]
         sleep_mock.assert_called_once_with(rpyc_process.POOL_INTERVAL)
 
     def test_running_when_poll_is_none(self, rpyc_process):
@@ -145,12 +159,14 @@ class TestRPyCProcess:
 
     def test_kill_no_wait(self, rpyc_process, mocker):
         rpyc_process._start_pipe_drain = mocker.create_autospec(rpyc_process._start_pipe_drain)
+        rpyc_process._stop_pipe_drain = mocker.create_autospec(rpyc_process._stop_pipe_drain)
         rpyc_process._get_and_kill_process = mocker.create_autospec(rpyc_process._get_and_kill_process)
         rpyc_process.wait = mocker.create_autospec(rpyc_process.wait)
         rpyc_process.kill(wait=None)
         rpyc_process._get_and_kill_process.assert_called_once_with(with_signal=SIGTERM)
         rpyc_process._start_pipe_drain.assert_called_once_with()
         rpyc_process.wait.assert_not_called()
+        rpyc_process._stop_pipe_drain.assert_not_called()
 
     def test_stdout_stream_raises_if_not_available(self, rpyc_process):
         rpyc_process._process.stdout = None
@@ -271,12 +287,14 @@ class TestRPyCProcess:
 
     def test_kill_wait(self, rpyc_process, mocker):
         rpyc_process._start_pipe_drain = mocker.create_autospec(rpyc_process._start_pipe_drain)
+        rpyc_process._stop_pipe_drain = mocker.create_autospec(rpyc_process._stop_pipe_drain)
         rpyc_process._get_and_kill_process = mocker.create_autospec(rpyc_process._get_and_kill_process)
         rpyc_process.wait = mocker.create_autospec(rpyc_process.wait)
         rpyc_process.kill(wait=10)
         rpyc_process._get_and_kill_process.assert_called_once_with(with_signal=SIGTERM)
         rpyc_process._start_pipe_drain.assert_called_once_with()
         rpyc_process.wait.assert_called_once_with(timeout=10)
+        rpyc_process._stop_pipe_drain.assert_called_once_with()
 
     def test_stop(self, rpyc_process, mocker):
         rpyc_process._start_pipe_drain = mocker.create_autospec(rpyc_process._start_pipe_drain)
@@ -303,6 +321,97 @@ class TestRPyCProcess:
         _stdout_queue_mock.side_effect = Exception()
         with pytest.raises(Exception):
             rpyc_process._start_pipe_drain()
+
+    def test__stop_pipe_drain_skips_stop_when_drained(self, rpyc_process, mocker):
+        # Watchers already finished (done/EOF) - trailing output fully captured, do not force stop.
+        stdout_done = mocker.Mock()
+        stdout_done.is_set.return_value = True
+        stderr_done = mocker.Mock()
+        stderr_done.is_set.return_value = True
+        rpyc_process._cached_stdout_queue = mocker.Mock()
+        rpyc_process._cached_stderr_queue = mocker.Mock()
+        rpyc_process._cached_stdout_stop_event = mocker.Mock()
+        rpyc_process._cached_stderr_stop_event = mocker.Mock()
+        rpyc_process._cached_stdout_done_event = stdout_done
+        rpyc_process._cached_stderr_done_event = stderr_done
+
+        rpyc_process._stop_pipe_drain(idle_timeout=1)
+
+        rpyc_process._cached_stdout_stop_event.set.assert_not_called()
+        rpyc_process._cached_stderr_stop_event.set.assert_not_called()
+
+    def test__stop_pipe_drain_sets_stop_when_idle(self, rpyc_process, sleep_mock, mocker):
+        # Stream produces no new output (constant progress) and never reaches EOF - force stop after idle.
+        timeout_mock = mocker.patch("mfd_connect.process.rpyc.base.TimeoutCounter")
+        timeout_mock.return_value.__bool__.return_value = True  # idle window already elapsed
+        done_event = mocker.Mock()
+        done_event.is_set.return_value = False
+        drainer = mocker.Mock()
+        drainer.progress.return_value = 5  # constant -> no progress
+        rpyc_process._cached_stdout_queue = drainer
+        rpyc_process._cached_stdout_stop_event = mocker.Mock()
+        rpyc_process._cached_stdout_done_event = done_event
+        rpyc_process._cached_stderr_queue = None
+        rpyc_process._cached_stderr_stop_event = None
+        rpyc_process._cached_stderr_done_event = None
+
+        rpyc_process._stop_pipe_drain()
+
+        rpyc_process._cached_stdout_stop_event.set.assert_called_once_with()
+
+    def test__stop_pipe_drain_sets_stop_when_max_timeout_exceeded(self, rpyc_process, sleep_mock, mocker):
+        # Output keeps flowing (idle never fires) but the absolute cap is hit - force stop to avoid a hang.
+        idle_counter = mocker.MagicMock()
+        idle_counter.__bool__.return_value = False
+        hard_counter = mocker.MagicMock()
+        hard_counter.__bool__.return_value = True
+
+        def _make_counter(value):
+            return hard_counter if value == 1 else idle_counter
+
+        mocker.patch("mfd_connect.process.rpyc.base.TimeoutCounter", side_effect=_make_counter)
+        done_event = mocker.Mock()
+        done_event.is_set.return_value = False
+        drainer = mocker.Mock()
+        drainer.progress.return_value = 1  # progress on first check resets idle, but hard cap still fires
+        rpyc_process._cached_stdout_queue = drainer
+        rpyc_process._cached_stdout_stop_event = mocker.Mock()
+        rpyc_process._cached_stdout_done_event = done_event
+        rpyc_process._cached_stderr_queue = None
+        rpyc_process._cached_stderr_stop_event = None
+        rpyc_process._cached_stderr_done_event = None
+
+        rpyc_process._stop_pipe_drain(idle_timeout=30, max_timeout=1)
+
+        rpyc_process._cached_stdout_stop_event.set.assert_called_once_with()
+
+    def test__stop_pipe_drain_waits_while_output_flows(self, rpyc_process, sleep_mock, mocker):
+        # progress keeps growing (backlog still buffering), then EOF - never force stop, no truncation.
+        done_event = mocker.Mock()
+        done_event.is_set.side_effect = [False, False, True]
+        drainer = mocker.Mock()
+        drainer.progress.side_effect = [1, 2]
+        rpyc_process._cached_stdout_queue = drainer
+        rpyc_process._cached_stdout_stop_event = mocker.Mock()
+        rpyc_process._cached_stdout_done_event = done_event
+        rpyc_process._cached_stderr_queue = None
+        rpyc_process._cached_stderr_stop_event = None
+        rpyc_process._cached_stderr_done_event = None
+
+        rpyc_process._stop_pipe_drain(idle_timeout=30)
+
+        rpyc_process._cached_stdout_stop_event.set.assert_not_called()
+
+    def test__stop_pipe_drain_no_events(self, rpyc_process):
+        rpyc_process._cached_stdout_queue = None
+        rpyc_process._cached_stderr_queue = None
+        rpyc_process._cached_stdout_stop_event = None
+        rpyc_process._cached_stderr_stop_event = None
+        rpyc_process._cached_stdout_done_event = None
+        rpyc_process._cached_stderr_done_event = None
+
+        # Should not raise when drain was never started.
+        rpyc_process._stop_pipe_drain()
 
     def test__kill_process(self, rpyc_process, mocker, caplog):
         caplog.set_level(log_levels.MODULE_DEBUG)
@@ -380,6 +489,148 @@ class TestRPyCProcess:
         converted_signal = rpyc_process._convert_to_signal_object(with_signal)
         assert converted_signal == rpyc_process._owner.modules().signal.Signals.SIGTERM
 
+    def test__iterate_non_blocking_queue_flushes_trailing_partial(self, rpyc_process, sleep_mock, mocker):
+        # A final line without a trailing newline must still be yielded once EOF is reached.
+        drainer = mocker.Mock()
+        drainer.drain.side_effect = [("last line no newline", True), ("", True)]
+
+        result = list(rpyc_process._iterate_non_blocking_queue(drainer))
+
+        assert result == ["last line no newline"]
+
     def test_pid(self, rpyc_process, mocker):
         check = mocker.sentinel.pid
         assert rpyc_process.pid == check
+
+    def test___init__(self, mocker):
+        self.class_under_test.__abstractmethods__ = frozenset()
+        owner = mocker.sentinel.owner
+        process = mocker.sentinel.process
+        log_path = mocker.sentinel.log_path
+        log_file_stream = mocker.sentinel.log_file_stream
+
+        proc = self.class_under_test(owner=owner, process=process, log_path=log_path, log_file_stream=log_file_stream)
+
+        assert proc._owner is owner
+        assert proc._process is process
+        assert proc.log_path is log_path
+        assert proc.log_file_stream is log_file_stream
+        assert proc._cached_remote_get_process_io_queue is None
+        assert proc._cached_stdout_queue is None
+        assert proc._cached_stdout_stop_event is None
+        assert proc._cached_stdout_done_event is None
+        assert proc._cached_stdout_iter is None
+        assert proc._cached_stderr_queue is None
+        assert proc._cached_stderr_stop_event is None
+        assert proc._cached_stderr_done_event is None
+        assert proc._cached_stderr_iter is None
+
+    def test__get_process_io_queue_reads_lines(self):
+        import io
+
+        stream = io.StringIO("line1\nline2\n")
+        drainer, stop_event, done_event = RPyCProcess._get_process_io_queue(stream)
+
+        assert done_event.wait(5)
+        assert drainer.progress() == 2
+        text, done = drainer.drain()
+
+        assert text == "line1\nline2\n"
+        assert done is True
+        assert isinstance(stop_event, threading.Event)
+        assert not stop_event.is_set()
+
+    def test__get_process_io_queue_breaks_when_stop_event_set(self):
+        gate = threading.Event()
+
+        class _Stream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                gate.wait(5)  # block until the test requests a stop
+                return "line\n"
+
+        drainer, stop_event, done_event = RPyCProcess._get_process_io_queue(_Stream())
+
+        stop_event.set()  # request stop while the watcher is blocked in __next__
+        gate.set()  # let __next__ return a line - watcher captures it, then breaks
+
+        assert done_event.wait(5)
+        text, done = drainer.drain()
+
+        # The already-read line must be captured, then the watcher stops (no infinite loop).
+        assert text == "line\n"
+        assert done is True
+
+    def test__get_process_io_queue_puts_error_on_exception(self, mocker):
+        # Silence the expected re-raised exception reported by the watcher daemon thread.
+        mocker.patch.object(threading, "excepthook", lambda args: None)
+
+        class _Stream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise RuntimeError("boom")
+
+        drainer, _, done_event = RPyCProcess._get_process_io_queue(_Stream())
+
+        assert done_event.wait(5)
+        text, done = drainer.drain()
+
+        assert "<internal>: Error occurred during io processing. Check responder log for details." in text
+        assert done is True
+
+    def test__get_and_kill_process(self, rpyc_process, mocker):
+        psutil_process = mocker.Mock()
+        child1 = mocker.Mock()
+        child2 = mocker.Mock()
+        rpyc_process._get_psutil_process = mocker.create_autospec(
+            rpyc_process._get_psutil_process, return_value=psutil_process
+        )
+        rpyc_process._get_children_processes = mocker.create_autospec(
+            rpyc_process._get_children_processes, return_value=[child1, child2]
+        )
+        rpyc_process._kill_process = mocker.create_autospec(rpyc_process._kill_process)
+        rpyc_process._owner.modules().psutil.wait_procs.return_value = ([child1], [child2])
+
+        rpyc_process._get_and_kill_process(with_signal=SIGTERM)
+
+        rpyc_process._kill_process.assert_any_call(child1, SIGTERM, is_child=True)
+        rpyc_process._kill_process.assert_any_call(child2, SIGTERM, is_child=True)
+        rpyc_process._kill_process.assert_any_call(psutil_process, SIGTERM)
+        rpyc_process._owner.modules().psutil.wait_procs.assert_called_once_with([child1, child2], timeout=5)
+        psutil_process.wait.assert_called_once_with(5)
+
+    def test__get_children_processes(self, rpyc_process, mocker):
+        process = mocker.Mock()
+        result = rpyc_process._get_children_processes(process=process)
+        process.children.assert_called_once_with(recursive=True)
+        assert result == process.children.return_value
+
+    def test__get_psutil_process(self, rpyc_process):
+        result = rpyc_process._get_psutil_process()
+        rpyc_process._owner.modules().psutil.Process.assert_called_with(rpyc_process._process.pid)
+        assert result == rpyc_process._owner.modules().psutil.Process.return_value
+
+    def test__get_psutil_process_raises_when_psutil_missing(self, rpyc_process, caplog):
+        caplog.set_level(log_levels.MODULE_DEBUG)
+        rpyc_process._owner.modules().psutil.Process.side_effect = ModuleNotFoundError
+
+        with pytest.raises(ModuleNotFoundError):
+            rpyc_process._get_psutil_process()
+
+        assert "Psutil module on remote machine is missing" in caplog.text

--- a/tests/unit/test_mfd_connect/test_process/test_rpyc/test_posix.py
+++ b/tests/unit/test_mfd_connect/test_process/test_rpyc/test_posix.py
@@ -46,6 +46,16 @@ class TestPosixRPyCProcess:
         rpyc_process._start_pipe_drain.assert_called_with()
         rpyc_process._get_and_kill_process.assert_called_once_with(with_signal=SIGINT)
 
+    def test_stop_with_wait(self, rpyc_process, mocker):
+        rpyc_process._start_pipe_drain = mocker.create_autospec(rpyc_process._start_pipe_drain)
+        rpyc_process._stop_pipe_drain = mocker.create_autospec(rpyc_process._stop_pipe_drain)
+        rpyc_process._get_and_kill_process = mocker.create_autospec(rpyc_process._get_and_kill_process)
+        rpyc_process.wait = mocker.create_autospec(rpyc_process.wait)
+        rpyc_process.stop(wait=10)
+        rpyc_process._get_and_kill_process.assert_called_once_with(with_signal=SIGINT)
+        rpyc_process.wait.assert_called_once_with(timeout=10)
+        rpyc_process._stop_pipe_drain.assert_called_once_with()
+
     def test_stop_already_finished_process_exception(self, rpyc_process):
         rpyc_process.running = False
 

--- a/tests/unit/test_mfd_connect/test_process/test_rpyc/test_windows.py
+++ b/tests/unit/test_mfd_connect/test_process/test_rpyc/test_windows.py
@@ -45,6 +45,30 @@ class TestWindowsRPyCProcess:
         rpyc_process._start_pipe_drain.assert_called_with()
         rpyc_process._get_and_kill_process.assert_called_once()
 
+    def test_stop_with_wait(self, rpyc_process, mocker):
+        rpyc_process._start_pipe_drain = mocker.create_autospec(rpyc_process._start_pipe_drain)
+        rpyc_process._stop_pipe_drain = mocker.create_autospec(rpyc_process._stop_pipe_drain)
+        rpyc_process._get_and_kill_process = mocker.create_autospec(rpyc_process._get_and_kill_process)
+        rpyc_process.wait = mocker.create_autospec(rpyc_process.wait)
+        rpyc_process.stop(wait=10)
+        rpyc_process._get_and_kill_process.assert_called_once_with(
+            with_signal=rpyc_process._owner.modules().signal.CTRL_C_EVENT
+        )
+        rpyc_process.wait.assert_called_once_with(timeout=10)
+        rpyc_process._stop_pipe_drain.assert_called_once_with()
+
+    def test_kill_unsupported_signal_changes_to_sigterm(self, rpyc_process, mocker):
+        super_kill = mocker.patch("mfd_connect.process.rpyc.windows.RPyCProcess.kill", autospec=True)
+        rpyc_process.kill(wait=None, with_signal="SIGKILL")
+        super_kill.assert_called_once_with(
+            rpyc_process, wait=None, with_signal=rpyc_process._owner.modules().signal.SIGTERM
+        )
+
+    def test_kill_supported_signal(self, rpyc_process, mocker):
+        super_kill = mocker.patch("mfd_connect.process.rpyc.windows.RPyCProcess.kill", autospec=True)
+        rpyc_process.kill(wait=None, with_signal="CTRL_C_EVENT")
+        super_kill.assert_called_once_with(rpyc_process, wait=None, with_signal="CTRL_C_EVENT")
+
     def test_stop_already_finished_process_exception(self, rpyc_process):
         rpyc_process.running = False
 


### PR DESCRIPTION
fix: Terminate RPyC process pipe-drain watcher threads on stop/kill

Remote stdout/stderr watcher threads were never stopped when a process was terminated, so if a detached child kept the pipe's write-end open they stayed alive and kept pushing output over the single shared RPyC connection.
These leaked threads accumulated across processes and progressively congested the connection, making each subsequent stop()/wait() slower.

Add a remote stop event to _get_process_io_queue and signal it via _stop_pipe_drain() after wait() in kill() and stop().